### PR TITLE
Project Scaffold (#3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ dkms.conf
 # Vim workspace.session
 *.vim
 *.swp
+
+# Claude Code
+CLAUDE.md

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.16)
+project(ash LANGUAGES C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+add_compile_options($<$<CONFIG:Debug>:-Wall>
+                    $<$<CONFIG:Debug>:-Wextra>
+                    $<$<CONFIG:Debug>:-Werror>)
+
+include_directories(include)
+
+# Server
+add_executable(ash-server server/main.c)
+
+# Client library
+add_library(libash_shared SHARED lib/ash.c)
+add_library(libash_static STATIC lib/ash.c)
+
+set_target_properties(libash_shared PROPERTIES OUTPUT_NAME ash)
+set_target_properties(libash_static PROPERTIES OUTPUT_NAME ash)

--- a/include/ash/ash.h
+++ b/include/ash/ash.h
@@ -1,0 +1,16 @@
+#ifndef ASH_H
+#define ASH_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ash - CAN bridge client library */
+
+typedef struct ash_ctx ash_ctx_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ASH_H */

--- a/lib/ash.c
+++ b/lib/ash.c
@@ -1,0 +1,1 @@
+#include "ash/ash.h"

--- a/server/main.c
+++ b/server/main.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+int main(void)
+{
+    printf("ash-server starting\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

- Creates the initial directory structure: `server/`, `lib/`, `include/ash/`, `examples/`
- Adds root `CMakeLists.txt` targeting CMake ≥ 3.16, C11, with `-Wall -Wextra -Werror` in Debug builds
- Wires up three CMake targets: `ash-server`, `libash_shared`, `libash_static`
- Adds minimal stubs: `server/main.c` (prints startup message and exits), `lib/ash.c`, `include/ash/ash.h`
- Adds `CLAUDE.md` to `.gitignore`

## Test plan

- [ ] `cmake -B build -DCMAKE_BUILD_TYPE=Debug && cmake --build build` exits 0
- [ ] `./build/ash-server` prints `ash-server starting` and exits 0
- [ ] No warnings under `-Wall -Wextra -Werror`

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)