### PR TITLE
Core Server Event Loop (#4)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,8 @@ add_compile_options($<$<CONFIG:Debug>:-Wall>
 include_directories(include)
 
 # Server
-add_executable(ash-server server/main.c)
+add_executable(ash-server server/main.c server/server.c)
+target_compile_definitions(ash-server PRIVATE _GNU_SOURCE)
 
 # Client library
 add_library(libash_shared SHARED lib/ash.c)

--- a/server/main.c
+++ b/server/main.c
@@ -1,7 +1,32 @@
-#include <stdio.h>
+#include "server.h"
 
-int main(void)
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+int main(int argc, char *argv[])
 {
-    printf("ash-server starting\n");
+    uint16_t    port        = DEFAULT_PORT;
+    const char *storage_dir = NULL;
+
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--port") == 0 && i + 1 < argc) {
+            port = (uint16_t)atoi(argv[++i]);
+        } else if (strcmp(argv[i], "--storage-dir") == 0 && i + 1 < argc) {
+            storage_dir = argv[++i];
+        } else {
+            fprintf(stderr, "Usage: %s [--port PORT] [--storage-dir DIR]\n",
+                    argv[0]);
+            return 1;
+        }
+    }
+
+    server_t s;
+    if (server_init(&s, port, storage_dir) < 0)
+        return 1;
+
+    server_run(&s);
+    server_destroy(&s);
     return 0;
 }

--- a/server/server.c
+++ b/server/server.c
@@ -1,0 +1,240 @@
+#include "server.h"
+
+#include <sys/epoll.h>
+#include <sys/signalfd.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <signal.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdio.h>
+#include <errno.h>
+
+/* -------------------------------------------------------------------------
+ * Static helpers
+ * ---------------------------------------------------------------------- */
+
+static void session_add(server_t *s, int fd)
+{
+    if (s->nsessions >= MAX_SESSIONS) {
+        fprintf(stderr, "session_add: no free session slots\n");
+        close(fd);
+        return;
+    }
+    for (int i = 0; i < MAX_SESSIONS; i++) {
+        if (s->sessions[i].fd < 0) {
+            s->sessions[i].fd = fd;
+            s->nsessions++;
+            return;
+        }
+    }
+    fprintf(stderr, "session_add: no free session slots\n");
+    close(fd);
+}
+
+static void session_remove(server_t *s, int fd)
+{
+    for (int i = 0; i < MAX_SESSIONS; i++) {
+        if (s->sessions[i].fd == fd) {
+            s->sessions[i].fd = -1;
+            s->nsessions--;
+            return;
+        }
+    }
+}
+
+/* -------------------------------------------------------------------------
+ * epoll helpers
+ * ---------------------------------------------------------------------- */
+
+int server_add_fd(server_t *s, int fd, uint32_t events)
+{
+    struct epoll_event ev;
+    ev.events  = events;
+    ev.data.fd = fd;
+    if (epoll_ctl(s->epoll_fd, EPOLL_CTL_ADD, fd, &ev) < 0) {
+        perror("epoll_ctl(ADD)");
+        return -1;
+    }
+    return 0;
+}
+
+int server_del_fd(server_t *s, int fd)
+{
+    if (epoll_ctl(s->epoll_fd, EPOLL_CTL_DEL, fd, NULL) < 0) {
+        perror("epoll_ctl(DEL)");
+        return -1;
+    }
+    return 0;
+}
+
+/* -------------------------------------------------------------------------
+ * server_init
+ * ---------------------------------------------------------------------- */
+
+int server_init(server_t *s, uint16_t port, const char *storage_dir)
+{
+    memset(s, 0, sizeof(*s));
+    s->epoll_fd   = -1;
+    s->listen_fd  = -1;
+    s->signal_fd  = -1;
+    s->port       = port;
+    s->storage_dir = storage_dir;
+
+    for (int i = 0; i < MAX_SESSIONS; i++)
+        s->sessions[i].fd = -1;
+
+    /* --- epoll instance --- */
+    s->epoll_fd = epoll_create1(EPOLL_CLOEXEC);
+    if (s->epoll_fd < 0) {
+        perror("epoll_create1");
+        return -1;
+    }
+
+    /* --- signalfd for SIGTERM + SIGINT --- */
+    sigset_t mask;
+    sigemptyset(&mask);
+    sigaddset(&mask, SIGTERM);
+    sigaddset(&mask, SIGINT);
+
+    if (sigprocmask(SIG_BLOCK, &mask, NULL) < 0) {
+        perror("sigprocmask");
+        return -1;
+    }
+
+    s->signal_fd = signalfd(-1, &mask, SFD_NONBLOCK | SFD_CLOEXEC);
+    if (s->signal_fd < 0) {
+        perror("signalfd");
+        return -1;
+    }
+
+    if (server_add_fd(s, s->signal_fd, EPOLLIN) < 0)
+        return -1;
+
+    /* --- TCP listener --- */
+    s->listen_fd = socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
+    if (s->listen_fd < 0) {
+        perror("socket");
+        return -1;
+    }
+
+    int opt = 1;
+    if (setsockopt(s->listen_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) < 0) {
+        perror("setsockopt(SO_REUSEADDR)");
+        return -1;
+    }
+
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family      = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    addr.sin_port        = htons(port);
+
+    if (bind(s->listen_fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+        perror("bind");
+        return -1;
+    }
+
+    if (listen(s->listen_fd, SOMAXCONN) < 0) {
+        perror("listen");
+        return -1;
+    }
+
+    if (server_add_fd(s, s->listen_fd, EPOLLIN) < 0)
+        return -1;
+
+    printf("ash-server listening on port %u\n", (unsigned)port);
+    return 0;
+}
+
+/* -------------------------------------------------------------------------
+ * server_run
+ * ---------------------------------------------------------------------- */
+
+void server_run(server_t *s)
+{
+    struct epoll_event events[64];
+
+    for (;;) {
+        int n = epoll_wait(s->epoll_fd, events, 64, -1);
+        if (n < 0) {
+            if (errno == EINTR)
+                continue;
+            perror("epoll_wait");
+            break;
+        }
+
+        for (int i = 0; i < n; i++) {
+            int fd = events[i].data.fd;
+
+            if (fd == s->signal_fd) {
+                /* Drain the signalfd */
+                struct signalfd_siginfo ssi;
+                (void)read(s->signal_fd, &ssi, sizeof(ssi));
+                printf("ash-server received signal %u, shutting down\n",
+                       ssi.ssi_signo);
+                return;
+
+            } else if (fd == s->listen_fd) {
+                /* Accept loop */
+                for (;;) {
+                    int cfd = accept4(s->listen_fd, NULL, NULL,
+                                      SOCK_NONBLOCK | SOCK_CLOEXEC);
+                    if (cfd < 0) {
+                        if (errno == EAGAIN || errno == EWOULDBLOCK)
+                            break;
+                        perror("accept4");
+                        break;
+                    }
+                    if (server_add_fd(s, cfd, EPOLLIN | EPOLLRDHUP) < 0) {
+                        close(cfd);
+                        continue;
+                    }
+                    session_add(s, cfd);
+                }
+
+            } else {
+                /* Client fd: error / hangup / peer closed */
+                if (events[i].events & (EPOLLHUP | EPOLLERR | EPOLLRDHUP)) {
+                    server_del_fd(s, fd);
+                    session_remove(s, fd);
+                    close(fd);
+                }
+            }
+        }
+    }
+}
+
+/* -------------------------------------------------------------------------
+ * server_destroy
+ * ---------------------------------------------------------------------- */
+
+void server_destroy(server_t *s)
+{
+    /* Notify and close all connected clients */
+    for (int i = 0; i < MAX_SESSIONS; i++) {
+        int fd = s->sessions[i].fd;
+        if (fd < 0)
+            continue;
+        (void)write(fd, NOTIFY_SERVER_CLOSING,
+                    sizeof(NOTIFY_SERVER_CLOSING) - 1);
+        server_del_fd(s, fd);
+        close(fd);
+        s->sessions[i].fd = -1;
+    }
+
+    if (s->listen_fd >= 0) {
+        close(s->listen_fd);
+        s->listen_fd = -1;
+    }
+    if (s->signal_fd >= 0) {
+        close(s->signal_fd);
+        s->signal_fd = -1;
+    }
+    if (s->epoll_fd >= 0) {
+        close(s->epoll_fd);
+        s->epoll_fd = -1;
+    }
+
+    printf("ash-server stopped\n");
+}

--- a/server/server.h
+++ b/server/server.h
@@ -1,0 +1,31 @@
+#ifndef ASH_SERVER_H
+#define ASH_SERVER_H
+
+#include <stdint.h>
+#include <sys/epoll.h>
+
+#define MAX_SESSIONS          1024
+#define DEFAULT_PORT          4000
+#define NOTIFY_SERVER_CLOSING "SERVER_CLOSING\r\n"
+
+typedef struct {
+    int fd;
+} session_t;
+
+typedef struct {
+    int         epoll_fd;
+    int         listen_fd;
+    int         signal_fd;
+    const char *storage_dir;
+    uint16_t    port;
+    session_t   sessions[MAX_SESSIONS];
+    int         nsessions;
+} server_t;
+
+int  server_init(server_t *s, uint16_t port, const char *storage_dir);
+void server_run(server_t *s);
+void server_destroy(server_t *s);
+int  server_add_fd(server_t *s, int fd, uint32_t events);
+int  server_del_fd(server_t *s, int fd);
+
+#endif /* ASH_SERVER_H */


### PR DESCRIPTION
## Summary

- Adds `server/server.h` and `server/server.c` with epoll instance management, fd registration/deregistration helpers, and session slot tracking (`MAX_SESSIONS = 1024`)
- Implements `signalfd`-based `SIGTERM`/`SIGINT` handling — signals are added to epoll and trigger a clean shutdown
- On shutdown: sends `NOTIFY_SERVER_CLOSING\r\n` to all connected clients, closes all fds, exits 0
- Accepts TCP connections via `accept4` loop and tracks them as placeholder session slots (no protocol parsing)
- Replaces `server/main.c` stub with `--port` / `--storage-dir` argument parsing (default port 4000)
- Updates `CMakeLists.txt` to add `server/server.c` and define `_GNU_SOURCE`

Closes #4

## Test plan

- [x] `cmake -B build -DCMAKE_BUILD_TYPE=Debug && cmake --build build` exits 0 with no warnings
- [x] `./build/ash-server` starts and blocks (prints listening message)
- [x] `./build/ash-server --port 5000` binds on port 5000
- [x] `kill -SIGTERM <pid>` causes clean shutdown with exit code 0
- [x] `nc localhost 4000` connects without crashing the server
- [x] Ctrl-C (`SIGINT`) causes clean shutdown with exit code 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)