### PR TITLE
Session Lifecycle (#6)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ add_compile_options($<$<CONFIG:Debug>:-Wall>
 include_directories(include)
 
 # Server
-add_executable(ash-server server/main.c server/server.c server/proto.c)
+add_executable(ash-server server/main.c server/server.c server/proto.c server/session.c)
 target_compile_definitions(ash-server PRIVATE _GNU_SOURCE)
 
 # Client library

--- a/server/server.c
+++ b/server/server.c
@@ -1,9 +1,11 @@
 #include "server.h"
 #include "proto.h"
+#include "session.h"
 
 #include <sys/epoll.h>
 #include <sys/signalfd.h>
 #include <sys/socket.h>
+#include <sys/timerfd.h>
 #include <netinet/in.h>
 #include <signal.h>
 #include <unistd.h>
@@ -24,7 +26,32 @@ static void session_add(server_t *s, int fd)
     }
     for (int i = 0; i < MAX_SESSIONS; i++) {
         if (s->sessions[i].fd < 0) {
-            s->sessions[i].fd = fd;
+            /* Create per-session timerfd for keep-alive enforcement */
+            int tfd = timerfd_create(CLOCK_MONOTONIC,
+                                     TFD_NONBLOCK | TFD_CLOEXEC);
+            if (tfd < 0) {
+                perror("timerfd_create");
+                close(fd);
+                return;
+            }
+
+            s->sessions[i].fd         = fd;
+            s->sessions[i].timer_fd   = tfd;
+            s->sessions[i].session_id = 0;
+            memset(s->sessions[i].client_name, 0,
+                   sizeof(s->sessions[i].client_name));
+
+            /* Arm immediately so unauthenticated connections also time out */
+            session_arm_timer(&s->sessions[i]);
+
+            if (server_add_fd(s, tfd, EPOLLIN) < 0) {
+                close(tfd);
+                close(fd);
+                s->sessions[i].fd       = -1;
+                s->sessions[i].timer_fd = -1;
+                return;
+            }
+
             s->nsessions++;
             return;
         }
@@ -37,7 +64,14 @@ static void session_remove(server_t *s, int fd)
 {
     for (int i = 0; i < MAX_SESSIONS; i++) {
         if (s->sessions[i].fd == fd) {
-            s->sessions[i].fd = -1;
+            int tfd = s->sessions[i].timer_fd;
+            if (tfd >= 0) {
+                server_del_fd(s, tfd);
+                close(tfd);
+                s->sessions[i].timer_fd = -1;
+            }
+            s->sessions[i].fd         = -1;
+            s->sessions[i].session_id = 0;
             s->nsessions--;
             return;
         }
@@ -82,8 +116,11 @@ int server_init(server_t *s, uint16_t port, const char *storage_dir)
     s->port       = port;
     s->storage_dir = storage_dir;
 
-    for (int i = 0; i < MAX_SESSIONS; i++)
-        s->sessions[i].fd = -1;
+    for (int i = 0; i < MAX_SESSIONS; i++) {
+        s->sessions[i].fd         = -1;
+        s->sessions[i].timer_fd   = -1;
+        s->sessions[i].session_id = 0;
+    }
 
     /* --- epoll instance --- */
     s->epoll_fd = epoll_create1(EPOLL_CLOEXEC);
@@ -144,6 +181,10 @@ int server_init(server_t *s, uint16_t port, const char *storage_dir)
     if (server_add_fd(s, s->listen_fd, EPOLLIN) < 0)
         return -1;
 
+    /* --- Session module --- */
+    session_set_server(s);
+    session_register_handlers();
+
     printf("ash-server listening on port %u\n", (unsigned)port);
     return 0;
 }
@@ -169,7 +210,6 @@ void server_run(server_t *s)
             int fd = events[i].data.fd;
 
             if (fd == s->signal_fd) {
-                /* Drain the signalfd */
                 struct signalfd_siginfo ssi;
                 (void)read(s->signal_fd, &ssi, sizeof(ssi));
                 printf("ash-server received signal %u, shutting down\n",
@@ -177,7 +217,6 @@ void server_run(server_t *s)
                 return;
 
             } else if (fd == s->listen_fd) {
-                /* Accept loop */
                 for (;;) {
                     int cfd = accept4(s->listen_fd, NULL, NULL,
                                       SOCK_NONBLOCK | SOCK_CLOEXEC);
@@ -195,21 +234,42 @@ void server_run(server_t *s)
                 }
 
             } else {
+                /* Check if this fd is a keep-alive timerfd */
+                session_t *tsess = session_find_by_timer_fd(s, fd);
+                if (tsess) {
+                    uint64_t exp;
+                    (void)read(fd, &exp, sizeof(exp));  /* drain timerfd */
+                    int client_fd = tsess->fd;
+                    fprintf(stderr,
+                            "ash-server: session %u timed out (fd=%d), closing\n",
+                            tsess->session_id, client_fd);
+                    session_cleanup(s, tsess);
+                    server_del_fd(s, client_fd);
+                    session_remove(s, client_fd);   /* closes timer_fd too */
+                    close(client_fd);
+                    continue;
+                }
+
                 /* Client fd: error / hangup / peer closed */
                 if (events[i].events & (EPOLLHUP | EPOLLERR | EPOLLRDHUP)) {
+                    session_t *sess = session_find_by_fd(s, fd);
+                    if (sess)
+                        session_cleanup(s, sess);
                     server_del_fd(s, fd);
                     session_remove(s, fd);
                     close(fd);
                     continue;
                 }
 
-                /* Client fd: data available — read and dispatch one frame */
+                /* Client fd: data available */
                 if (events[i].events & EPOLLIN) {
                     proto_frame_t frame;
                     int close_session = 0;
 
                     if (proto_read_frame(fd, &frame) < 0) {
-                        /* I/O error or clean EOF */
+                        session_t *sess = session_find_by_fd(s, fd);
+                        if (sess)
+                            session_cleanup(s, sess);
                         server_del_fd(s, fd);
                         session_remove(s, fd);
                         close(fd);
@@ -222,6 +282,9 @@ void server_run(server_t *s)
                         proto_send_err(fd, (uint16_t)err_code, NULL);
                         proto_frame_free(&frame);
                         if (close_session) {
+                            session_t *sess = session_find_by_fd(s, fd);
+                            if (sess)
+                                session_cleanup(s, sess);
                             server_del_fd(s, fd);
                             session_remove(s, fd);
                             close(fd);
@@ -229,10 +292,25 @@ void server_run(server_t *s)
                         continue;
                     }
 
+                    /* Reset keep-alive timer on any message from an
+                     * established session (SESSION_INIT arms it itself) */
+                    session_t *sess = session_find_by_fd(s, fd);
+                    if (sess && sess->session_id != 0)
+                        session_arm_timer(sess);
+
+                    /* Session guard: check state vs message type */
+                    if (session_guard(fd, frame.hdr.msg_type) != 0) {
+                        proto_frame_free(&frame);
+                        continue;
+                    }
+
                     int rc = proto_dispatch(fd, &frame);
                     proto_frame_free(&frame);
 
                     if (rc < 0) {
+                        session_t *csess = session_find_by_fd(s, fd);
+                        if (csess)
+                            session_cleanup(s, csess);
                         server_del_fd(s, fd);
                         session_remove(s, fd);
                         close(fd);
@@ -249,13 +327,19 @@ void server_run(server_t *s)
 
 void server_destroy(server_t *s)
 {
-    /* Notify and close all connected clients */
     for (int i = 0; i < MAX_SESSIONS; i++) {
         int fd = s->sessions[i].fd;
         if (fd < 0)
             continue;
+        session_cleanup(s, &s->sessions[i]);
         (void)proto_send_ack(fd, MSG_NOTIFY_SERVER_CLOSE, NULL, 0);
         server_del_fd(s, fd);
+        int tfd = s->sessions[i].timer_fd;
+        if (tfd >= 0) {
+            server_del_fd(s, tfd);
+            close(tfd);
+            s->sessions[i].timer_fd = -1;
+        }
         close(fd);
         s->sessions[i].fd = -1;
     }

--- a/server/server.h
+++ b/server/server.h
@@ -1,14 +1,19 @@
 #ifndef ASH_SERVER_H
 #define ASH_SERVER_H
 
+#include "ash/proto.h"
 #include <stdint.h>
 #include <sys/epoll.h>
 
 #define MAX_SESSIONS          1024
 #define DEFAULT_PORT          4000
+#define KEEPALIVE_TIMEOUT_SEC 30
 
 typedef struct {
-    int fd;
+    int      fd;
+    int      timer_fd;
+    uint32_t session_id;                       /* 0 = not yet established */
+    char     client_name[PROTO_MAX_NAME + 1];
 } session_t;
 
 typedef struct {

--- a/server/session.c
+++ b/server/session.c
@@ -1,0 +1,203 @@
+#include "session.h"
+#include "proto.h"
+
+#include "ash/proto.h"
+
+#include <sys/timerfd.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdio.h>
+#include <unistd.h>
+
+/* -------------------------------------------------------------------------
+ * Module state
+ * ---------------------------------------------------------------------- */
+
+static server_t *g_server = NULL;
+
+static uint32_t next_session_id = 1;  /* 0 is reserved for "no session" */
+
+/* -------------------------------------------------------------------------
+ * Global server pointer
+ * ---------------------------------------------------------------------- */
+
+void session_set_server(server_t *s)
+{
+    g_server = s;
+}
+
+/* -------------------------------------------------------------------------
+ * Session lookup helpers
+ * ---------------------------------------------------------------------- */
+
+session_t *session_find_by_fd(server_t *s, int fd)
+{
+    for (int i = 0; i < MAX_SESSIONS; i++) {
+        if (s->sessions[i].fd == fd)
+            return &s->sessions[i];
+    }
+    return NULL;
+}
+
+session_t *session_find_by_timer_fd(server_t *s, int tfd)
+{
+    for (int i = 0; i < MAX_SESSIONS; i++) {
+        if (s->sessions[i].fd >= 0 && s->sessions[i].timer_fd == tfd)
+            return &s->sessions[i];
+    }
+    return NULL;
+}
+
+/* -------------------------------------------------------------------------
+ * Keep-alive timer
+ * ---------------------------------------------------------------------- */
+
+void session_arm_timer(session_t *sess)
+{
+    struct itimerspec its;
+    its.it_value.tv_sec  = KEEPALIVE_TIMEOUT_SEC;
+    its.it_value.tv_nsec = 0;
+    its.it_interval.tv_sec  = 0;
+    its.it_interval.tv_nsec = 0;
+    if (timerfd_settime(sess->timer_fd, 0, &its, NULL) < 0)
+        perror("timerfd_settime");
+}
+
+/* -------------------------------------------------------------------------
+ * Resource cleanup
+ * ---------------------------------------------------------------------- */
+
+void session_cleanup(server_t *s, session_t *sess)
+{
+    (void)s;
+    /* Future: release owned signals, detach interfaces */
+    sess->session_id = 0;
+    memset(sess->client_name, 0, sizeof(sess->client_name));
+}
+
+/* -------------------------------------------------------------------------
+ * Pre-dispatch session guard
+ * ---------------------------------------------------------------------- */
+
+int session_guard(int fd, uint16_t msg_type)
+{
+    session_t *sess = session_find_by_fd(g_server, fd);
+    if (!sess)
+        return -1;
+
+    if (msg_type == MSG_SESSION_INIT) {
+        if (sess->session_id != 0) {
+            proto_send_err(fd, ERR_ALREADY_IN_SESSION, NULL);
+            return -1;
+        }
+    } else {
+        if (sess->session_id == 0) {
+            proto_send_err(fd, ERR_NOT_IN_SESSION, NULL);
+            return -1;
+        }
+    }
+    return 0;
+}
+
+/* -------------------------------------------------------------------------
+ * Message handlers
+ * ---------------------------------------------------------------------- */
+
+/*
+ * SESSION_INIT  (SPEC §4.1)
+ *
+ * Payload: 1-byte name_len + name_len bytes of client name (UTF-8).
+ * Response: SESSION_INIT_ACK with 4-byte big-endian session ID.
+ */
+static int handle_session_init(int fd, const proto_frame_t *frame)
+{
+    session_t *sess = session_find_by_fd(g_server, fd);
+    if (!sess)
+        return -1;
+
+    /* Parse client name */
+    uint8_t name_len = 0;
+    if (frame->hdr.payload_len >= 1)
+        name_len = frame->payload[0];
+
+    if (name_len > PROTO_MAX_NAME) {
+        proto_send_err(fd, ERR_NAME_TOO_LONG, NULL);
+        return 0;
+    }
+
+    if (frame->hdr.payload_len < (uint32_t)(1u + name_len)) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    /* Assign session */
+    sess->session_id = next_session_id++;
+    if (next_session_id == 0)
+        next_session_id = 1;   /* skip reserved 0 on wraparound */
+
+    memcpy(sess->client_name, &frame->payload[1], name_len);
+    sess->client_name[name_len] = '\0';
+
+    /* Arm the keep-alive timer */
+    session_arm_timer(sess);
+
+    printf("ash-server: session %u established (client=\"%s\", fd=%d)\n",
+           sess->session_id, sess->client_name, fd);
+
+    /* Send ACK: 4-byte big-endian session ID */
+    uint8_t ack[4];
+    ack[0] = (sess->session_id >> 24) & 0xFF;
+    ack[1] = (sess->session_id >> 16) & 0xFF;
+    ack[2] = (sess->session_id >>  8) & 0xFF;
+    ack[3] =  sess->session_id        & 0xFF;
+    proto_send_ack(fd, MSG_SESSION_INIT_ACK, ack, 4);
+
+    return 0;
+}
+
+/*
+ * SESSION_KEEPALIVE  (SPEC §4.2)
+ *
+ * No payload, no response.  The keep-alive timer is reset by server_run()
+ * in the EPOLLIN path before dispatch, so this handler is a no-op.
+ */
+static int handle_session_keepalive(int fd, const proto_frame_t *frame)
+{
+    (void)fd;
+    (void)frame;
+    return 0;
+}
+
+/*
+ * SESSION_CLOSE  (SPEC §4.3)
+ *
+ * No payload.  Release all session resources, send SESSION_CLOSE_ACK,
+ * then signal the server to close the TCP connection (return -1).
+ */
+static int handle_session_close(int fd, const proto_frame_t *frame)
+{
+    (void)frame;
+
+    session_t *sess = session_find_by_fd(g_server, fd);
+    if (!sess)
+        return -1;
+
+    printf("ash-server: session %u closing (client=\"%s\", fd=%d)\n",
+           sess->session_id, sess->client_name, fd);
+
+    session_cleanup(g_server, sess);
+    proto_send_ack(fd, MSG_SESSION_CLOSE_ACK, NULL, 0);
+
+    return -1;  /* instruct server_run() to close the connection */
+}
+
+/* -------------------------------------------------------------------------
+ * Handler registration
+ * ---------------------------------------------------------------------- */
+
+void session_register_handlers(void)
+{
+    proto_register_handler(MSG_SESSION_INIT,      handle_session_init);
+    proto_register_handler(MSG_SESSION_KEEPALIVE, handle_session_keepalive);
+    proto_register_handler(MSG_SESSION_CLOSE,     handle_session_close);
+}

--- a/server/session.h
+++ b/server/session.h
@@ -1,0 +1,65 @@
+#ifndef ASH_SESSION_H
+#define ASH_SESSION_H
+
+#include "server.h"
+#include <stdint.h>
+
+/* -------------------------------------------------------------------------
+ * Global server pointer — must be set before any session function is called.
+ * ---------------------------------------------------------------------- */
+
+void session_set_server(server_t *s);
+
+/* -------------------------------------------------------------------------
+ * Session lookup helpers
+ * ---------------------------------------------------------------------- */
+
+session_t *session_find_by_fd(server_t *s, int fd);
+session_t *session_find_by_timer_fd(server_t *s, int tfd);
+
+/* -------------------------------------------------------------------------
+ * Keep-alive timer
+ *
+ * Arms (or rearms) the per-session timerfd to fire after
+ * KEEPALIVE_TIMEOUT_SEC seconds.  Call after any message is received from
+ * an established session.
+ * ---------------------------------------------------------------------- */
+
+void session_arm_timer(session_t *sess);
+
+/* -------------------------------------------------------------------------
+ * Resource cleanup
+ *
+ * Releases all resources held by *sess (owned signals, attached interfaces).
+ * Clears session state but does NOT close the TCP fd or remove it from
+ * epoll — that is the caller's responsibility.
+ * ---------------------------------------------------------------------- */
+
+void session_cleanup(server_t *s, session_t *sess);
+
+/* -------------------------------------------------------------------------
+ * Pre-dispatch session guard  (SPEC §4)
+ *
+ * Checks that the incoming message type is consistent with the current
+ * session state on *fd*:
+ *
+ *   - SESSION_INIT on an already-established session → ERR_ALREADY_IN_SESSION
+ *   - Any other message before session is established → ERR_NOT_IN_SESSION
+ *
+ * Returns  0 if dispatch should proceed.
+ * Returns -1 if the guard sent an error and dispatch must be skipped
+ *            (the connection stays open in both cases).
+ * ---------------------------------------------------------------------- */
+
+int session_guard(int fd, uint16_t msg_type);
+
+/* -------------------------------------------------------------------------
+ * Handler registration
+ *
+ * Registers handlers for SESSION_INIT, SESSION_KEEPALIVE, SESSION_CLOSE.
+ * Must be called after session_set_server().
+ * ---------------------------------------------------------------------- */
+
+void session_register_handlers(void);
+
+#endif /* ASH_SESSION_H */

--- a/tools/test_client.py
+++ b/tools/test_client.py
@@ -1,21 +1,23 @@
 #!/usr/bin/env python3
 """
-ash protocol test client — exercises all PR #25 test cases.
+ash protocol test client — exercises wire protocol and session lifecycle.
 
 Usage:
     ./tools/test_client.py [--host HOST] [--port PORT] [--test N]
 
 Default host/port: 127.0.0.1:4000
 
-Tests 1-4 run automatically.  Test 5 (graceful shutdown) requires you to
-stop the server manually while the client is connected, so it is skipped in
-a full run unless --test 5 is given explicitly.
+Tests 1-7 run automatically.
+Test 8 (graceful server shutdown) requires manually stopping the server and
+must be requested with --test 8.
+Test 9 (keep-alive timeout) waits 30+ seconds and must be requested with --test 9.
 """
 
 import argparse
 import socket
 import struct
 import sys
+import time
 
 # ── Wire constants (mirrors include/ash/proto.h) ──────────────────────────────
 
@@ -24,12 +26,21 @@ PROTO_HEADER_SIZE       = 8
 PROTO_MAX_PAYLOAD       = 65535
 
 MSG_SESSION_INIT        = 0x0001
+MSG_SESSION_KEEPALIVE   = 0x0002
+MSG_SESSION_CLOSE       = 0x0003
+MSG_SESSION_INIT_ACK    = 0x8001
+MSG_SESSION_CLOSE_ACK   = 0x8003
 MSG_ERR                 = 0xFFFF
 MSG_NOTIFY_SERVER_CLOSE = 0x9003
 
 ERR_PROTOCOL_VERSION     = 0x0001
 ERR_UNKNOWN_MESSAGE_TYPE = 0x0002
 ERR_PAYLOAD_TOO_LARGE    = 0x0003
+ERR_NOT_IN_SESSION       = 0x0004
+ERR_ALREADY_IN_SESSION   = 0x0005
+ERR_NAME_TOO_LONG        = 0x0006
+
+KEEPALIVE_TIMEOUT_SEC    = 30
 
 # ── Frame helpers ─────────────────────────────────────────────────────────────
 
@@ -37,6 +48,12 @@ def make_frame(version, msg_type, payload=b''):
     """Return a complete wire frame: 8-byte header + payload."""
     header = struct.pack('>HHI', version, msg_type, len(payload))
     return header + payload
+
+
+def make_session_init(client_name='test-client'):
+    name = client_name.encode()
+    payload = bytes([len(name)]) + name
+    return make_frame(PROTO_VERSION, MSG_SESSION_INIT, payload)
 
 
 def recv_frame(sock):
@@ -72,11 +89,21 @@ def decode_err(payload):
     return code, payload[2:]
 
 
+def parse_session_id(payload):
+    """Parse 4-byte big-endian session ID from SESSION_INIT_ACK payload."""
+    if len(payload) < 4:
+        return None
+    return struct.unpack('>I', payload[:4])[0]
+
+
 # ── Pretty-printers ───────────────────────────────────────────────────────────
 
 MSG_NAMES = {
     0x0001: 'SESSION_INIT',
+    0x0002: 'SESSION_KEEPALIVE',
+    0x0003: 'SESSION_CLOSE',
     0x8001: 'SESSION_INIT_ACK',
+    0x8003: 'SESSION_CLOSE_ACK',
     0x9003: 'NOTIFY_SERVER_CLOSE',
     0xFFFF: 'MSG_ERR',
 }
@@ -85,6 +112,9 @@ ERR_NAMES = {
     0x0001: 'ERR_PROTOCOL_VERSION',
     0x0002: 'ERR_UNKNOWN_MESSAGE_TYPE',
     0x0003: 'ERR_PAYLOAD_TOO_LARGE',
+    0x0004: 'ERR_NOT_IN_SESSION',
+    0x0005: 'ERR_ALREADY_IN_SESSION',
+    0x0006: 'ERR_NAME_TOO_LONG',
 }
 
 def fmt_type(t):
@@ -104,6 +134,9 @@ def print_response(frame):
         code, msg = decode_err(payload)
         print(f'            err_code={fmt_err(code)}'
               + (f'  msg={msg.decode(errors="replace")!r}' if msg else ''))
+    elif msg_type == MSG_SESSION_INIT_ACK:
+        sid = parse_session_id(payload)
+        print(f'            session_id={sid}')
 
 
 def check(cond, label):
@@ -111,46 +144,11 @@ def check(cond, label):
     return cond
 
 
-# ── Individual test cases ─────────────────────────────────────────────────────
-
-def test_valid_session_init(host, port):
-    """
-    Test 1 — Valid SESSION_INIT (version=0x0001, type=0x0001)
-
-    No handlers are registered in the current build, so proto_dispatch() falls
-    through to the default path and returns ERR_UNKNOWN_MESSAGE_TYPE while
-    keeping the connection open.  The test verifies the response code and that
-    the connection is still usable after the error reply.
-    """
-    print('\n[1] Valid SESSION_INIT — expect ERR_UNKNOWN_MESSAGE_TYPE, connection kept open')
-    with socket.create_connection((host, port), timeout=3) as s:
-        s.sendall(make_frame(PROTO_VERSION, MSG_SESSION_INIT))
-        frame = recv_frame(s)
-        print_response(frame)
-        if not check(frame is not None, 'received a response'):
-            return
-        _, msg_type, payload = frame
-        check(msg_type == MSG_ERR,
-              f'response is MSG_ERR (got {fmt_type(msg_type)})')
-        code, _ = decode_err(payload)
-        check(code == ERR_UNKNOWN_MESSAGE_TYPE,
-              f'err_code is ERR_UNKNOWN_MESSAGE_TYPE (got {fmt_err(code)})')
-
-        # Verify connection is still open by sending a second frame.
-        s.sendall(make_frame(PROTO_VERSION, MSG_SESSION_INIT))
-        frame2 = recv_frame(s)
-        check(frame2 is not None,
-              'connection stayed open (second frame got a response)')
-
+# ── Protocol framing tests (originally PR #25) ────────────────────────────────
 
 def test_bad_version(host, port):
-    """
-    Test 2 — Frame with version != 0x0001
-
-    proto_validate_header() should reply ERR_PROTOCOL_VERSION (0x0001) and
-    set close_conn=1, causing the server to close the connection.
-    """
-    print('\n[2] Bad protocol version (0x00FF) — expect ERR_PROTOCOL_VERSION, connection closed')
+    """Test 1 — Bad protocol version → ERR_PROTOCOL_VERSION, connection closed."""
+    print('\n[1] Bad protocol version (0x00FF) — expect ERR_PROTOCOL_VERSION, connection closed')
     with socket.create_connection((host, port), timeout=3) as s:
         s.sendall(make_frame(0x00FF, MSG_SESSION_INIT))
         frame = recv_frame(s)
@@ -158,34 +156,22 @@ def test_bad_version(host, port):
         if not check(frame is not None, 'received a response'):
             return
         _, msg_type, payload = frame
-        check(msg_type == MSG_ERR,
-              f'response is MSG_ERR (got {fmt_type(msg_type)})')
+        check(msg_type == MSG_ERR, f'response is MSG_ERR (got {fmt_type(msg_type)})')
         code, _ = decode_err(payload)
         check(code == ERR_PROTOCOL_VERSION,
               f'err_code is ERR_PROTOCOL_VERSION (got {fmt_err(code)})')
-
-        # Connection should be closed — a subsequent read should return EOF.
         s.settimeout(1)
         try:
             tail = s.recv(8)
-            check(tail == b'', 'connection closed by server after ERR')
+            check(tail == b'', 'connection closed by server')
         except socket.timeout:
-            check(False, 'connection closed by server (timed out — still open?)')
+            check(False, 'connection closed by server (timed out)')
 
 
 def test_payload_too_large(host, port):
-    """
-    Test 3 — payload_len > PROTO_MAX_PAYLOAD (65535)
-
-    The server calls proto_read_frame() before proto_validate_header(), so it
-    will malloc and recv the full declared payload before validating.  We must
-    send the complete 65536-byte payload or proto_read_exact() will block.
-
-    Expected: ERR_PAYLOAD_TOO_LARGE (0x0003), connection closed.
-    """
-    oversized = PROTO_MAX_PAYLOAD + 1   # 65536
-    print(f'\n[3] Oversized payload (payload_len={oversized}) — expect ERR_PAYLOAD_TOO_LARGE, connection closed')
-    print( '    (sending full payload so the server can advance to validation)')
+    """Test 2 — payload_len > 65535 → ERR_PAYLOAD_TOO_LARGE, connection closed."""
+    oversized = PROTO_MAX_PAYLOAD + 1
+    print(f'\n[2] Oversized payload ({oversized} bytes) — expect ERR_PAYLOAD_TOO_LARGE, connection closed')
     with socket.create_connection((host, port), timeout=10) as s:
         s.sendall(make_frame(PROTO_VERSION, MSG_SESSION_INIT, b'\x00' * oversized))
         frame = recv_frame(s)
@@ -193,62 +179,145 @@ def test_payload_too_large(host, port):
         if not check(frame is not None, 'received a response'):
             return
         _, msg_type, payload = frame
-        check(msg_type == MSG_ERR,
-              f'response is MSG_ERR (got {fmt_type(msg_type)})')
+        check(msg_type == MSG_ERR, f'response is MSG_ERR (got {fmt_type(msg_type)})')
         code, _ = decode_err(payload)
         check(code == ERR_PAYLOAD_TOO_LARGE,
               f'err_code is ERR_PAYLOAD_TOO_LARGE (got {fmt_err(code)})')
-
         s.settimeout(1)
         try:
             tail = s.recv(8)
-            check(tail == b'', 'connection closed by server after ERR')
+            check(tail == b'', 'connection closed by server')
         except socket.timeout:
-            check(False, 'connection closed by server (timed out — still open?)')
+            check(False, 'connection closed by server (timed out)')
 
 
 def test_unknown_type(host, port):
-    """
-    Test 4 — Unregistered message type (0x7FFF)
-
-    proto_dispatch() finds no handler and sends ERR_UNKNOWN_MESSAGE_TYPE
-    (0x0002).  The connection must remain open.
-    """
-    unknown = 0x7FFF
-    print(f'\n[4] Unknown message type (0x{unknown:04X}) — expect ERR_UNKNOWN_MESSAGE_TYPE, connection kept open')
+    """Test 3 — Unregistered message type after session → ERR_UNKNOWN_MESSAGE_TYPE, open."""
+    print('\n[3] Unknown message type after session — expect ERR_UNKNOWN_MESSAGE_TYPE, connection kept open')
     with socket.create_connection((host, port), timeout=3) as s:
-        s.sendall(make_frame(PROTO_VERSION, unknown))
+        # Establish session first
+        s.sendall(make_session_init())
+        frame = recv_frame(s)
+        if frame is None or frame[1] != MSG_SESSION_INIT_ACK:
+            check(False, 'could not establish session (prerequisite failed)')
+            return
+        # Send unknown type
+        s.sendall(make_frame(PROTO_VERSION, 0x7FFF))
         frame = recv_frame(s)
         print_response(frame)
         if not check(frame is not None, 'received a response'):
             return
         _, msg_type, payload = frame
-        check(msg_type == MSG_ERR,
-              f'response is MSG_ERR (got {fmt_type(msg_type)})')
+        check(msg_type == MSG_ERR, f'response is MSG_ERR (got {fmt_type(msg_type)})')
         code, _ = decode_err(payload)
         check(code == ERR_UNKNOWN_MESSAGE_TYPE,
               f'err_code is ERR_UNKNOWN_MESSAGE_TYPE (got {fmt_err(code)})')
-
-        s.sendall(make_frame(PROTO_VERSION, MSG_SESSION_INIT))
+        s.sendall(make_frame(PROTO_VERSION, MSG_SESSION_KEEPALIVE))
         frame2 = recv_frame(s)
-        check(frame2 is not None,
-              'connection stayed open (second frame got a response)')
+        # SESSION_KEEPALIVE has no response; send another unknown to confirm open
+        s.sendall(make_frame(PROTO_VERSION, 0x7FFF))
+        frame3 = recv_frame(s)
+        check(frame3 is not None, 'connection stayed open')
+
+# ── Session lifecycle tests ───────────────────────────────────────────────────
+
+def test_session_init(host, port):
+    """Test 4 — SESSION_INIT → SESSION_INIT_ACK with non-zero session ID."""
+    print('\n[4] SESSION_INIT — expect SESSION_INIT_ACK with non-zero session ID')
+    with socket.create_connection((host, port), timeout=3) as s:
+        s.sendall(make_session_init('my-client'))
+        frame = recv_frame(s)
+        print_response(frame)
+        if not check(frame is not None, 'received a response'):
+            return
+        _, msg_type, payload = frame
+        check(msg_type == MSG_SESSION_INIT_ACK,
+              f'response is SESSION_INIT_ACK (got {fmt_type(msg_type)})')
+        sid = parse_session_id(payload)
+        check(sid is not None and sid != 0, f'session_id is non-zero (got {sid})')
+
+
+def test_already_in_session(host, port):
+    """Test 5 — SESSION_INIT on active session → ERR_ALREADY_IN_SESSION."""
+    print('\n[5] SESSION_INIT on active session — expect ERR_ALREADY_IN_SESSION')
+    with socket.create_connection((host, port), timeout=3) as s:
+        s.sendall(make_session_init('client-a'))
+        frame = recv_frame(s)
+        if frame is None or frame[1] != MSG_SESSION_INIT_ACK:
+            check(False, 'could not establish session (prerequisite failed)')
+            return
+        s.sendall(make_session_init('client-b'))
+        frame = recv_frame(s)
+        print_response(frame)
+        if not check(frame is not None, 'received a response'):
+            return
+        _, msg_type, payload = frame
+        check(msg_type == MSG_ERR, f'response is MSG_ERR (got {fmt_type(msg_type)})')
+        code, _ = decode_err(payload)
+        check(code == ERR_ALREADY_IN_SESSION,
+              f'err_code is ERR_ALREADY_IN_SESSION (got {fmt_err(code)})')
+
+
+def test_not_in_session(host, port):
+    """Test 6 — Non-SESSION_INIT before session established → ERR_NOT_IN_SESSION."""
+    print('\n[6] Message before SESSION_INIT — expect ERR_NOT_IN_SESSION')
+    with socket.create_connection((host, port), timeout=3) as s:
+        s.sendall(make_frame(PROTO_VERSION, MSG_SESSION_KEEPALIVE))
+        frame = recv_frame(s)
+        print_response(frame)
+        if not check(frame is not None, 'received a response'):
+            return
+        _, msg_type, payload = frame
+        check(msg_type == MSG_ERR, f'response is MSG_ERR (got {fmt_type(msg_type)})')
+        code, _ = decode_err(payload)
+        check(code == ERR_NOT_IN_SESSION,
+              f'err_code is ERR_NOT_IN_SESSION (got {fmt_err(code)})')
+        # Connection should remain open
+        s.sendall(make_session_init('late-client'))
+        frame2 = recv_frame(s)
+        check(frame2 is not None and frame2[1] == MSG_SESSION_INIT_ACK,
+              'connection stayed open; SESSION_INIT still accepted')
+
+
+def test_session_close(host, port):
+    """Test 7 — SESSION_CLOSE → SESSION_CLOSE_ACK, connection closed."""
+    print('\n[7] SESSION_CLOSE — expect SESSION_CLOSE_ACK, connection closed')
+    with socket.create_connection((host, port), timeout=3) as s:
+        s.sendall(make_session_init('closing-client'))
+        frame = recv_frame(s)
+        if frame is None or frame[1] != MSG_SESSION_INIT_ACK:
+            check(False, 'could not establish session (prerequisite failed)')
+            return
+        s.sendall(make_frame(PROTO_VERSION, MSG_SESSION_CLOSE))
+        frame = recv_frame(s)
+        print_response(frame)
+        if not check(frame is not None, 'received a response'):
+            return
+        _, msg_type, _ = frame
+        check(msg_type == MSG_SESSION_CLOSE_ACK,
+              f'response is SESSION_CLOSE_ACK (got {fmt_type(msg_type)})')
+        s.settimeout(1)
+        try:
+            tail = s.recv(8)
+            check(tail == b'', 'connection closed by server after ACK')
+        except socket.timeout:
+            check(False, 'connection closed by server (timed out)')
 
 
 def test_server_close(host, port):
     """
-    Test 5 — Graceful server shutdown
-
-    Connect, then stop the server (Ctrl-C or SIGTERM).  The server's
-    server_destroy() sends a wire-framed NOTIFY_SERVER_CLOSE (0x9003) to every
-    connected client before closing their fds.
-
-    This test waits up to 60 seconds for the frame.  Press Ctrl-C here to skip.
+    Test 8 — Graceful server shutdown → NOTIFY_SERVER_CLOSE (0x9003).
+    Requires manually stopping the server (Ctrl-C) while this test waits.
     """
-    print('\n[5] Graceful shutdown — connect and stop the server (Ctrl-C on server)')
-    print('    Waiting up to 60 s for NOTIFY_SERVER_CLOSE (0x9003) … (Ctrl-C here to skip)')
+    print('\n[8] Graceful shutdown — stop the server now (Ctrl-C on server)')
+    print('    Waiting up to 60 s for NOTIFY_SERVER_CLOSE … (Ctrl-C here to skip)')
     try:
         with socket.create_connection((host, port), timeout=60) as s:
+            s.sendall(make_session_init('shutdown-watcher'))
+            ack = recv_frame(s)
+            if ack is None or ack[1] != MSG_SESSION_INIT_ACK:
+                check(False, 'could not establish session')
+                return
             s.settimeout(60)
             frame = recv_frame(s)
             print_response(frame)
@@ -261,26 +330,56 @@ def test_server_close(host, port):
         print('  [skipped]')
 
 
+def test_keepalive_timeout(host, port):
+    """
+    Test 9 — Keep-alive timeout (30 s).
+    Connects, establishes a session, then stays idle.  The server should
+    close the connection after KEEPALIVE_TIMEOUT_SEC seconds.
+    """
+    wait = KEEPALIVE_TIMEOUT_SEC + 5
+    print(f'\n[9] Keep-alive timeout — connecting and waiting {wait} s without sending anything')
+    with socket.create_connection((host, port), timeout=wait + 5) as s:
+        s.sendall(make_session_init('idle-client'))
+        frame = recv_frame(s)
+        if frame is None or frame[1] != MSG_SESSION_INIT_ACK:
+            check(False, 'could not establish session')
+            return
+        print(f'  session established, waiting {wait} s for timeout …')
+        s.settimeout(wait + 5)
+        start = time.monotonic()
+        tail = s.recv(8)
+        elapsed = time.monotonic() - start
+        check(tail == b'',
+              f'connection closed by server (EOF received after {elapsed:.1f} s)')
+        check(elapsed >= KEEPALIVE_TIMEOUT_SEC - 1,
+              f'closed after at least {KEEPALIVE_TIMEOUT_SEC - 1} s '
+              f'(actual: {elapsed:.1f} s)')
+
+
 # ── Entry point ───────────────────────────────────────────────────────────────
 
 TESTS = [
-    test_valid_session_init,
-    test_bad_version,
-    test_payload_too_large,
-    test_unknown_type,
-    test_server_close,
+    test_bad_version,           # 1
+    test_payload_too_large,     # 2
+    test_unknown_type,          # 3
+    test_session_init,          # 4
+    test_already_in_session,    # 5
+    test_not_in_session,        # 6
+    test_session_close,         # 7
+    test_server_close,          # 8  — interactive
+    test_keepalive_timeout,     # 9  — slow (30+ s)
 ]
+
+AUTO_TESTS = TESTS[:7]   # 1-7 run unattended
 
 
 def main():
     parser = argparse.ArgumentParser(
-        description='ash protocol test client (PR #25 / issue #5)')
-    parser.add_argument('--host', default='127.0.0.1',
-                        help='server host (default: 127.0.0.1)')
-    parser.add_argument('--port', type=int, default=4000,
-                        help='server port (default: 4000)')
-    parser.add_argument('--test', type=int, choices=range(1, 6), metavar='N',
-                        help='run only test N (1-5)')
+        description='ash protocol + session lifecycle test client')
+    parser.add_argument('--host', default='127.0.0.1')
+    parser.add_argument('--port', type=int, default=4000)
+    parser.add_argument('--test', type=int, choices=range(1, len(TESTS) + 1),
+                        metavar='N', help=f'run only test N (1-{len(TESTS)})')
     args = parser.parse_args()
 
     print(f'ash test client — {args.host}:{args.port}')
@@ -296,10 +395,10 @@ def main():
     if args.test:
         run(TESTS[args.test - 1])
     else:
-        # Run tests 1-4 automatically; test 5 needs manual server intervention.
-        for fn in TESTS[:-1]:
+        for fn in AUTO_TESTS:
             run(fn)
-        print('\n[5] Graceful shutdown — run with --test 5 to execute interactively')
+        print('\n[8] Graceful shutdown  — run with --test 8')
+        print('[9] Keep-alive timeout — run with --test 9 (takes 35 s)')
 
     print()
 


### PR DESCRIPTION
Closes #6

## Summary

- **session.h / session.c** — new session module encapsulating all session lifecycle logic
  - `handle_session_init`: parses 1-byte name_len + UTF-8 client name, assigns a non-zero u32 session ID, arms the per-session timerfd, responds with `SESSION_INIT_ACK` (4-byte big-endian session ID)
  - `handle_session_keepalive`: no-op handler (timer is reset in `server_run` on every EPOLLIN from an established session per SPEC §4.2)
  - `handle_session_close`: calls `session_cleanup()`, sends `SESSION_CLOSE_ACK`, returns -1 to signal connection teardown
  - `session_guard()`: sends `ERR_ALREADY_IN_SESSION` if `SESSION_INIT` arrives on an active session; sends `ERR_NOT_IN_SESSION` for any other message before a session is established
  - `session_arm_timer()`: arms/rearms a one-shot `CLOCK_MONOTONIC` timerfd to `KEEPALIVE_TIMEOUT_SEC` (30 s)
  - `session_cleanup()`: clears session state; stub comment marks where ownership release and interface detach will go

- **server.h** — `session_t` expanded with `timer_fd`, `session_id`, `client_name`; `KEEPALIVE_TIMEOUT_SEC` constant added

- **server.c**
  - `session_add()`: creates a `timerfd` per accepted connection and arms it immediately (unauthenticated connections also time out)
  - `session_remove()`: closes and epoll-removes the `timerfd`
  - `server_run()`: timer fd EPOLLIN handled as keep-alive expiry (drain, `session_cleanup`, close client fd silently); `session_guard()` called before `proto_dispatch()`; `session_cleanup()` called on all disconnect paths (EOF, error, hangup, `SESSION_CLOSE`, timeout)
  - `server_init()`: calls `session_set_server()` + `session_register_handlers()`

- **tools/test_client.py** — extended with six session lifecycle tests (tests 4–9)

## Test plan

- [x] `SESSION_INIT` with a valid client name → `SESSION_INIT_ACK` with non-zero session ID (`--test 4`)
- [x] `SESSION_INIT` on an already-active session → `ERR_ALREADY_IN_SESSION`, connection stays open (`--test 5`)
- [x] Any message (e.g. `SESSION_KEEPALIVE`) before `SESSION_INIT` → `ERR_NOT_IN_SESSION`, connection stays open; subsequent `SESSION_INIT` still accepted (`--test 6`)
- [x] `SESSION_CLOSE` → `SESSION_CLOSE_ACK`, server closes TCP connection (`--test 7`)
- [x] Server shutdown while client is connected → `NOTIFY_SERVER_CLOSE` frame received (`--test 8`, interactive)
- [x] Idle session for 35 s → server silently closes connection after 30 s timeout (`--test 9`, slow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)