### PR TITLE
#8: CAN Interface Management (SPEC §7)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ add_compile_options($<$<CONFIG:Debug>:-Wall>
 include_directories(include)
 
 # Server
-add_executable(ash-server server/main.c server/server.c server/proto.c server/session.c)
+add_executable(ash-server server/main.c server/server.c server/proto.c server/session.c server/iface.c)
 target_compile_definitions(ash-server PRIVATE _GNU_SOURCE)
 
 # Client library

--- a/server/iface.c
+++ b/server/iface.c
@@ -1,0 +1,962 @@
+/* =========================================================================
+ * server/iface.c — CAN Interface Management  (SPEC §7)
+ *
+ * Implements:
+ *   IFACE_LIST        — enumerate available CAN interfaces
+ *   IFACE_ATTACH      — open SocketCAN socket, expose app-plane TCP port
+ *   IFACE_DETACH      — close SocketCAN socket and app-plane listener
+ *   IFACE_VCAN_CREATE — create a virtual CAN interface via NETLINK_ROUTE
+ *   IFACE_VCAN_DESTROY— destroy a virtual CAN interface via NETLINK_ROUTE
+ *
+ * All multi-byte values on the wire are big-endian (SPEC §3.2).
+ * ========================================================================= */
+
+#include "iface.h"
+#include "proto.h"
+#include "session.h"
+#include "ash/proto.h"
+
+#include <linux/can.h>
+#include <linux/can/raw.h>
+#include <linux/can/netlink.h>
+#include <linux/rtnetlink.h>
+#include <linux/netlink.h>
+#include <net/if.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <errno.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdint.h>
+
+/* ARPHRD_CAN is 280; define it if the system headers don't provide it. */
+#ifndef ARPHRD_CAN
+#define ARPHRD_CAN 280
+#endif
+
+#define MAX_IFACE_TABLE  64
+#define NL_BUF_SIZE      8192
+
+/* -------------------------------------------------------------------------
+ * Interface attachment table
+ * ---------------------------------------------------------------------- */
+
+typedef struct {
+    char     name[IFNAMSIZ];
+    uint32_t session_id;      /* 0 = not attached */
+    int      client_fd;       /* TCP fd of owning client (-1 if none) */
+    int      can_fd;          /* SocketCAN socket fd (-1 if not attached) */
+    int      app_listen_fd;   /* application-plane TCP listener fd */
+    uint16_t app_port;        /* application-plane port */
+} iface_entry_t;
+
+static iface_entry_t g_iface_table[MAX_IFACE_TABLE];
+static int           g_iface_count;
+static server_t     *g_server;
+static int           g_netlink_fd = -1;   /* RTMGRP_LINK monitoring socket */
+static uint32_t      g_nl_seq     = 1;    /* per-process netlink sequence counter */
+
+/* -------------------------------------------------------------------------
+ * Netlink helpers
+ * ---------------------------------------------------------------------- */
+
+/* Pointer to the next attribute slot after the current message content. */
+#define NLMSG_TAIL(n) \
+    ((struct rtattr *)(((char *)(n)) + NLMSG_ALIGN((n)->nlmsg_len)))
+
+/*
+ * Append a netlink attribute to message *n.
+ * Returns 0 on success, -1 if the buffer would overflow.
+ */
+static int nl_addattr(struct nlmsghdr *n, size_t maxlen,
+                      int type, const void *data, int alen)
+{
+    size_t len = RTA_LENGTH((size_t)alen);
+    if (NLMSG_ALIGN(n->nlmsg_len) + RTA_ALIGN(len) > maxlen)
+        return -1;
+    struct rtattr *rta = NLMSG_TAIL(n);
+    rta->rta_type = (unsigned short)type;
+    rta->rta_len  = (unsigned short)len;
+    if (alen && data)
+        memcpy(RTA_DATA(rta), data, (size_t)alen);
+    n->nlmsg_len = (unsigned int)(NLMSG_ALIGN(n->nlmsg_len) + RTA_ALIGN(len));
+    return 0;
+}
+
+/* Begin a nested attribute; returns a pointer to the nest header. */
+static struct rtattr *nl_nest_start(struct nlmsghdr *n, size_t maxlen, int type)
+{
+    struct rtattr *nest = NLMSG_TAIL(n);
+    nl_addattr(n, maxlen, type, NULL, 0);
+    return nest;
+}
+
+/* Finish a nested attribute started with nl_nest_start(). */
+static void nl_nest_end(struct nlmsghdr *n, struct rtattr *nest)
+{
+    nest->rta_len = (unsigned short)((char *)NLMSG_TAIL(n) - (char *)nest);
+}
+
+/* Open a bound AF_NETLINK/NETLINK_ROUTE socket for one-shot operations. */
+static int nl_open_temp(void)
+{
+    int fd = socket(AF_NETLINK, SOCK_RAW | SOCK_CLOEXEC, NETLINK_ROUTE);
+    if (fd < 0)
+        return -1;
+    struct sockaddr_nl sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.nl_family = AF_NETLINK;
+    if (bind(fd, (struct sockaddr *)&sa, sizeof(sa)) < 0) {
+        close(fd);
+        return -1;
+    }
+    return fd;
+}
+
+/*
+ * Send a netlink message and block until we receive NLMSG_ERROR (ACK/NAK).
+ * Returns 0 on success (ACK with error == 0), -1 on failure.
+ */
+static int nl_talk(int fd, struct nlmsghdr *req, size_t req_len)
+{
+    if (send(fd, req, req_len, 0) < 0)
+        return -1;
+
+    char buf[NL_BUF_SIZE];
+    for (;;) {
+        ssize_t n = recv(fd, buf, sizeof(buf), 0);
+        if (n < 0)
+            return -1;
+        struct nlmsghdr *h = (struct nlmsghdr *)(void *)buf;
+        for (; NLMSG_OK(h, (unsigned int)n); h = NLMSG_NEXT(h, n)) {
+            if (h->nlmsg_type == NLMSG_ERROR) {
+                struct nlmsgerr *err = NLMSG_DATA(h);
+                if (err->error != 0) {
+                    errno = -(err->error);
+                    return -1;
+                }
+                return 0;
+            }
+            if (h->nlmsg_type == NLMSG_DONE)
+                return 0;
+        }
+        break;
+    }
+    return 0;
+}
+
+/* -------------------------------------------------------------------------
+ * CAN interface enumeration via RTM_GETLINK dump
+ * ---------------------------------------------------------------------- */
+
+typedef struct {
+    char name[IFNAMSIZ];
+} can_iface_info_t;
+
+/*
+ * Enumerate all CAN interfaces (ifi_type == ARPHRD_CAN).
+ * Fills *out with at most *max* entries and returns the count found,
+ * or -1 on error.
+ */
+static int enumerate_can_ifaces(can_iface_info_t *out, int max)
+{
+    int fd = nl_open_temp();
+    if (fd < 0)
+        return -1;
+
+    struct {
+        struct nlmsghdr  nlh;
+        struct ifinfomsg ifm;
+    } req;
+    memset(&req, 0, sizeof(req));
+    req.nlh.nlmsg_len   = NLMSG_LENGTH(sizeof(struct ifinfomsg));
+    req.nlh.nlmsg_type  = RTM_GETLINK;
+    req.nlh.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
+    req.nlh.nlmsg_seq   = g_nl_seq++;
+    req.ifm.ifi_family  = AF_UNSPEC;
+
+    if (send(fd, &req, req.nlh.nlmsg_len, 0) < 0) {
+        close(fd);
+        return -1;
+    }
+
+    int  count = 0;
+    int  done  = 0;
+    char buf[NL_BUF_SIZE];
+    while (!done) {
+        ssize_t n = recv(fd, buf, sizeof(buf), 0);
+        if (n < 0)
+            break;
+        struct nlmsghdr *h = (struct nlmsghdr *)(void *)buf;
+        for (; NLMSG_OK(h, (unsigned int)n); h = NLMSG_NEXT(h, n)) {
+            if (h->nlmsg_type == NLMSG_DONE) { done = 1; break; }
+            if (h->nlmsg_type == NLMSG_ERROR) { done = 1; break; }
+            if (h->nlmsg_type != RTM_NEWLINK)  continue;
+
+            struct ifinfomsg *ifi = NLMSG_DATA(h);
+            if (ifi->ifi_type != ARPHRD_CAN)
+                continue;
+
+            int attr_len = (int)(h->nlmsg_len - NLMSG_LENGTH(sizeof(*ifi)));
+            struct rtattr *attr = IFLA_RTA(ifi);
+            for (; RTA_OK(attr, attr_len); attr = RTA_NEXT(attr, attr_len)) {
+                if (attr->rta_type == IFLA_IFNAME && count < max) {
+                    strncpy(out[count].name, RTA_DATA(attr), IFNAMSIZ - 1);
+                    out[count].name[IFNAMSIZ - 1] = '\0';
+                    count++;
+                    break;
+                }
+            }
+        }
+    }
+    close(fd);
+    return count;
+}
+
+/* -------------------------------------------------------------------------
+ * Attachment table helpers
+ * ---------------------------------------------------------------------- */
+
+static iface_entry_t *iface_table_find(const char *name)
+{
+    for (int i = 0; i < g_iface_count; i++) {
+        if (strcmp(g_iface_table[i].name, name) == 0)
+            return &g_iface_table[i];
+    }
+    return NULL;
+}
+
+static iface_entry_t *iface_table_get_or_add(const char *name)
+{
+    iface_entry_t *e = iface_table_find(name);
+    if (e)
+        return e;
+    if (g_iface_count >= MAX_IFACE_TABLE)
+        return NULL;
+    e = &g_iface_table[g_iface_count++];
+    memset(e, 0, sizeof(*e));
+    strncpy(e->name, name, IFNAMSIZ - 1);
+    e->can_fd        = -1;
+    e->app_listen_fd = -1;
+    e->client_fd     = -1;
+    return e;
+}
+
+static void iface_entry_detach(iface_entry_t *e)
+{
+    if (e->can_fd >= 0) {
+        close(e->can_fd);
+        e->can_fd = -1;
+    }
+    if (e->app_listen_fd >= 0) {
+        close(e->app_listen_fd);
+        e->app_listen_fd = -1;
+    }
+    e->session_id = 0;
+    e->client_fd  = -1;
+    e->app_port   = 0;
+}
+
+/* -------------------------------------------------------------------------
+ * Bitrate configuration via netlink  (SPEC §7.2)
+ *
+ * Brings the interface down, sets IFLA_CAN_BITTIMING, brings it back up.
+ * A bitrate of 0 is a no-op (caller should not call this function with 0).
+ * ---------------------------------------------------------------------- */
+
+static int iface_set_bitrate(const char *ifname, uint32_t bitrate)
+{
+    unsigned int ifindex = if_nametoindex(ifname);
+    if (ifindex == 0)
+        return -1;
+
+    int fd = nl_open_temp();
+    if (fd < 0)
+        return -1;
+
+    /* Step 1: bring interface DOWN */
+    {
+        struct {
+            struct nlmsghdr  nlh;
+            struct ifinfomsg ifi;
+        } req;
+        memset(&req, 0, sizeof(req));
+        req.nlh.nlmsg_len   = NLMSG_LENGTH(sizeof(req.ifi));
+        req.nlh.nlmsg_type  = RTM_NEWLINK;
+        req.nlh.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
+        req.nlh.nlmsg_seq   = g_nl_seq++;
+        req.ifi.ifi_family  = AF_UNSPEC;
+        req.ifi.ifi_index   = (int)ifindex;
+        req.ifi.ifi_flags   = 0;
+        req.ifi.ifi_change  = IFF_UP;
+        if (nl_talk(fd, &req.nlh, req.nlh.nlmsg_len) < 0) {
+            close(fd);
+            return -1;
+        }
+    }
+
+    /* Step 2: set bittiming */
+    {
+        char buf[512];
+        memset(buf, 0, sizeof(buf));
+        struct nlmsghdr  *nlh = (struct nlmsghdr *)(void *)buf;
+        struct ifinfomsg *ifi = NLMSG_DATA(nlh);
+
+        nlh->nlmsg_len   = NLMSG_LENGTH(sizeof(*ifi));
+        nlh->nlmsg_type  = RTM_NEWLINK;
+        nlh->nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
+        nlh->nlmsg_seq   = g_nl_seq++;
+        ifi->ifi_family  = AF_UNSPEC;
+        ifi->ifi_index   = (int)ifindex;
+
+        struct rtattr *linkinfo = nl_nest_start(nlh, sizeof(buf), IFLA_LINKINFO);
+        const char *kind = "can";
+        nl_addattr(nlh, sizeof(buf), IFLA_INFO_KIND, kind, (int)strlen(kind) + 1);
+        struct rtattr *data = nl_nest_start(nlh, sizeof(buf), IFLA_INFO_DATA);
+
+        struct can_bittiming bt;
+        memset(&bt, 0, sizeof(bt));
+        bt.bitrate = bitrate;
+        nl_addattr(nlh, sizeof(buf), IFLA_CAN_BITTIMING, &bt, (int)sizeof(bt));
+
+        nl_nest_end(nlh, data);
+        nl_nest_end(nlh, linkinfo);
+
+        if (nl_talk(fd, nlh, nlh->nlmsg_len) < 0) {
+            fprintf(stderr,
+                    "ash-server: warning: could not set bitrate %u on %s: %s\n",
+                    bitrate, ifname, strerror(errno));
+            /* Non-fatal: interface may already be at the requested rate. */
+        }
+    }
+
+    /* Step 3: bring interface UP */
+    {
+        struct {
+            struct nlmsghdr  nlh;
+            struct ifinfomsg ifi;
+        } req;
+        memset(&req, 0, sizeof(req));
+        req.nlh.nlmsg_len   = NLMSG_LENGTH(sizeof(req.ifi));
+        req.nlh.nlmsg_type  = RTM_NEWLINK;
+        req.nlh.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
+        req.nlh.nlmsg_seq   = g_nl_seq++;
+        req.ifi.ifi_family  = AF_UNSPEC;
+        req.ifi.ifi_index   = (int)ifindex;
+        req.ifi.ifi_flags   = IFF_UP;
+        req.ifi.ifi_change  = IFF_UP;
+        if (nl_talk(fd, &req.nlh, req.nlh.nlmsg_len) < 0) {
+            close(fd);
+            return -1;
+        }
+    }
+
+    close(fd);
+    return 0;
+}
+
+/* -------------------------------------------------------------------------
+ * Virtual CAN management via RTM_NEWLINK / RTM_DELLINK  (SPEC §7.4)
+ * ---------------------------------------------------------------------- */
+
+static int vcan_create(const char *name)
+{
+    int fd = nl_open_temp();
+    if (fd < 0)
+        return -1;
+
+    /* RTM_NEWLINK: create the vcan interface */
+    char buf[512];
+    memset(buf, 0, sizeof(buf));
+    struct nlmsghdr  *nlh = (struct nlmsghdr *)(void *)buf;
+    struct ifinfomsg *ifi = NLMSG_DATA(nlh);
+
+    nlh->nlmsg_len   = NLMSG_LENGTH(sizeof(*ifi));
+    nlh->nlmsg_type  = RTM_NEWLINK;
+    nlh->nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL;
+    nlh->nlmsg_seq   = g_nl_seq++;
+    ifi->ifi_family  = AF_UNSPEC;
+
+    nl_addattr(nlh, sizeof(buf), IFLA_IFNAME, name, (int)strlen(name) + 1);
+    struct rtattr *linkinfo = nl_nest_start(nlh, sizeof(buf), IFLA_LINKINFO);
+    const char *kind = "vcan";
+    nl_addattr(nlh, sizeof(buf), IFLA_INFO_KIND, kind, (int)strlen(kind) + 1);
+    nl_nest_end(nlh, linkinfo);
+
+    int ret = nl_talk(fd, nlh, nlh->nlmsg_len);
+    close(fd);
+    if (ret < 0)
+        return -1;
+
+    /* Bring the interface up */
+    unsigned int ifindex = if_nametoindex(name);
+    if (ifindex == 0)
+        return -1;
+
+    fd = nl_open_temp();
+    if (fd < 0)
+        return -1;
+
+    struct {
+        struct nlmsghdr  nlh;
+        struct ifinfomsg ifi;
+    } req;
+    memset(&req, 0, sizeof(req));
+    req.nlh.nlmsg_len   = NLMSG_LENGTH(sizeof(req.ifi));
+    req.nlh.nlmsg_type  = RTM_NEWLINK;
+    req.nlh.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
+    req.nlh.nlmsg_seq   = g_nl_seq++;
+    req.ifi.ifi_family  = AF_UNSPEC;
+    req.ifi.ifi_index   = (int)ifindex;
+    req.ifi.ifi_flags   = IFF_UP;
+    req.ifi.ifi_change  = IFF_UP;
+
+    ret = nl_talk(fd, &req.nlh, req.nlh.nlmsg_len);
+    close(fd);
+    return ret;
+}
+
+static int vcan_destroy(const char *name)
+{
+    unsigned int ifindex = if_nametoindex(name);
+    if (ifindex == 0) {
+        errno = ENODEV;
+        return -1;
+    }
+
+    int fd = nl_open_temp();
+    if (fd < 0)
+        return -1;
+
+    struct {
+        struct nlmsghdr  nlh;
+        struct ifinfomsg ifi;
+    } req;
+    memset(&req, 0, sizeof(req));
+    req.nlh.nlmsg_len   = NLMSG_LENGTH(sizeof(req.ifi));
+    req.nlh.nlmsg_type  = RTM_DELLINK;
+    req.nlh.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
+    req.nlh.nlmsg_seq   = g_nl_seq++;
+    req.ifi.ifi_family  = AF_UNSPEC;
+    req.ifi.ifi_index   = (int)ifindex;
+
+    int ret = nl_talk(fd, &req.nlh, req.nlh.nlmsg_len);
+    close(fd);
+    return ret;
+}
+
+/* -------------------------------------------------------------------------
+ * Application-plane TCP listener
+ * ---------------------------------------------------------------------- */
+
+static int create_app_listener(uint16_t *port_out)
+{
+    int fd = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, 0);
+    if (fd < 0)
+        return -1;
+
+    int opt = 1;
+    setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+    struct sockaddr_in sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sin_family      = AF_INET;
+    sa.sin_addr.s_addr = INADDR_ANY;
+    sa.sin_port        = 0;   /* kernel assigns ephemeral port */
+
+    if (bind(fd, (struct sockaddr *)&sa, sizeof(sa)) < 0 ||
+        listen(fd, 8) < 0) {
+        close(fd);
+        return -1;
+    }
+
+    socklen_t slen = sizeof(sa);
+    if (getsockname(fd, (struct sockaddr *)&sa, &slen) < 0) {
+        close(fd);
+        return -1;
+    }
+    *port_out = ntohs(sa.sin_port);
+    return fd;
+}
+
+/* -------------------------------------------------------------------------
+ * Message handlers
+ * ---------------------------------------------------------------------- */
+
+/*
+ * IFACE_LIST  (SPEC §7.1)
+ *
+ * Request: no payload.
+ * Response (MSG_IFACE_LIST_RESP):
+ *   1B  interface count
+ *   for each:
+ *     1B  name_len
+ *     NB  name
+ *     1B  state  (0x01=available, 0x02=attached-this, 0x03=attached-other)
+ */
+static int handle_iface_list(int fd, const proto_frame_t *frame)
+{
+    (void)frame;
+
+    session_t *sess = session_find_by_fd(g_server, fd);
+    if (!sess)
+        return -1;
+
+    can_iface_info_t ifaces[MAX_IFACE_TABLE];
+    int count = enumerate_can_ifaces(ifaces, MAX_IFACE_TABLE);
+    if (count < 0)
+        count = 0;
+
+    uint8_t buf[8192];
+    int     pos = 0;
+    buf[pos++] = (uint8_t)count;
+
+    for (int i = 0; i < count; i++) {
+        uint8_t nlen = (uint8_t)strlen(ifaces[i].name);
+        buf[pos++] = nlen;
+        memcpy(&buf[pos], ifaces[i].name, nlen);
+        pos += nlen;
+
+        iface_entry_t *e = iface_table_find(ifaces[i].name);
+        uint8_t state;
+        if (!e || e->session_id == 0)
+            state = 0x01;
+        else if (e->session_id == sess->session_id)
+            state = 0x02;
+        else
+            state = 0x03;
+        buf[pos++] = state;
+    }
+
+    return proto_send_ack(fd, MSG_IFACE_LIST_RESP, buf, (uint32_t)pos);
+}
+
+/*
+ * IFACE_ATTACH  (SPEC §7.2)
+ *
+ * Payload:
+ *   1B  name_len
+ *   NB  name
+ *   1B  mode  (0x01=CAN2.0A, 0x02=CAN2.0B, 0x03=CAN FD)
+ *   4B  bitrate (big-endian, bps; 0 = do not reconfigure)
+ *   1B  filter_count
+ *   for each filter:
+ *     4B  can_id  (big-endian)
+ *     4B  mask    (big-endian)
+ *
+ * Response (MSG_IFACE_ATTACH_ACK):
+ *   2B  app_port (big-endian)
+ */
+static int handle_iface_attach(int fd, const proto_frame_t *frame)
+{
+    session_t *sess = session_find_by_fd(g_server, fd);
+    if (!sess)
+        return -1;
+
+    /* Minimum: name_len(1) + name(≥1) + mode(1) + bitrate(4) + filter_count(1) */
+    if (frame->hdr.payload_len < 8u) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    const uint8_t *p         = frame->payload;
+    uint32_t       remaining = frame->hdr.payload_len;
+
+    uint8_t name_len = *p++; remaining--;
+    if (name_len == 0 || name_len > PROTO_MAX_NAME ||
+        remaining < (uint32_t)name_len) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    char name[PROTO_MAX_NAME + 1];
+    memcpy(name, p, name_len);
+    name[name_len] = '\0';
+    p += name_len; remaining -= name_len;
+
+    if (remaining < 6u) {   /* mode(1) + bitrate(4) + filter_count(1) */
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    uint8_t  mode    = *p++; remaining--;
+    uint32_t bitrate = ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16)
+                     | ((uint32_t)p[2] <<  8) |  (uint32_t)p[3];
+    p += 4; remaining -= 4;
+    uint8_t filter_count = *p++; remaining--;
+
+    if (remaining < (uint32_t)filter_count * 8u) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    /* Verify the interface exists */
+    if (if_nametoindex(name) == 0) {
+        proto_send_err(fd, ERR_IFACE_NOT_FOUND, NULL);
+        return 0;
+    }
+
+    /* Enforce exclusive attachment */
+    iface_entry_t *e = iface_table_find(name);
+    if (e && e->session_id != 0) {
+        proto_send_err(fd, ERR_IFACE_ALREADY_ATTACHED, NULL);
+        return 0;
+    }
+
+    /* Optionally configure bitrate */
+    if (bitrate != 0 && iface_set_bitrate(name, bitrate) < 0)
+        fprintf(stderr, "ash-server: bitrate config failed for %s (continuing)\n",
+                name);
+
+    /* Open SocketCAN socket */
+    int can_sock = socket(AF_CAN, SOCK_RAW, CAN_RAW);
+    if (can_sock < 0) {
+        proto_send_err(fd, ERR_IFACE_ATTACH_FAILED, NULL);
+        return 0;
+    }
+
+    /* Enable CAN FD frames when mode requests it */
+    if (mode == 0x03) {
+        int enable = 1;
+        if (setsockopt(can_sock, SOL_CAN_RAW, CAN_RAW_FD_FRAMES,
+                       &enable, sizeof(enable)) < 0) {
+            close(can_sock);
+            proto_send_err(fd, ERR_IFACE_ATTACH_FAILED, NULL);
+            return 0;
+        }
+    }
+
+    /* Apply RX filters (zero filter_count leaves the socket promiscuous) */
+    if (filter_count > 0) {
+        struct can_filter filters[256];   /* max 255 entries (uint8_t count) */
+        for (int i = 0; i < (int)filter_count; i++) {
+            filters[i].can_id   = ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16)
+                                 | ((uint32_t)p[2] <<  8) |  (uint32_t)p[3];
+            filters[i].can_mask = ((uint32_t)p[4] << 24) | ((uint32_t)p[5] << 16)
+                                 | ((uint32_t)p[6] <<  8) |  (uint32_t)p[7];
+            p += 8;
+        }
+        if (setsockopt(can_sock, SOL_CAN_RAW, CAN_RAW_FILTER,
+                       filters,
+                       (socklen_t)(filter_count * sizeof(struct can_filter))) < 0) {
+            close(can_sock);
+            proto_send_err(fd, ERR_IFACE_ATTACH_FAILED, NULL);
+            return 0;
+        }
+    }
+
+    /* Bind to the named interface */
+    struct sockaddr_can addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.can_family  = AF_CAN;
+    addr.can_ifindex = (int)if_nametoindex(name);
+    if (bind(can_sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+        close(can_sock);
+        proto_send_err(fd, ERR_IFACE_ATTACH_FAILED, NULL);
+        return 0;
+    }
+
+    /* Create application-plane TCP listener on an ephemeral port */
+    uint16_t app_port = 0;
+    int app_fd = create_app_listener(&app_port);
+    if (app_fd < 0) {
+        close(can_sock);
+        proto_send_err(fd, ERR_IFACE_ATTACH_FAILED, NULL);
+        return 0;
+    }
+
+    /* Record the attachment */
+    e = iface_table_get_or_add(name);
+    if (!e) {
+        close(can_sock);
+        close(app_fd);
+        proto_send_err(fd, ERR_IFACE_ATTACH_FAILED, NULL);
+        return 0;
+    }
+    e->session_id    = sess->session_id;
+    e->client_fd     = fd;
+    e->can_fd        = can_sock;
+    e->app_listen_fd = app_fd;
+    e->app_port      = app_port;
+
+    printf("ash-server: session %u attached to %s (mode=0x%02x, app port=%u)\n",
+           sess->session_id, name, mode, app_port);
+
+    /* IFACE_ATTACH_ACK: 2-byte big-endian port */
+    uint8_t ack[2];
+    ack[0] = (uint8_t)((app_port >> 8) & 0xFFu);
+    ack[1] = (uint8_t)( app_port       & 0xFFu);
+    return proto_send_ack(fd, MSG_IFACE_ATTACH_ACK, ack, 2);
+}
+
+/*
+ * IFACE_DETACH  (SPEC §7.3)
+ *
+ * Payload:
+ *   1B  name_len
+ *   NB  name
+ */
+static int handle_iface_detach(int fd, const proto_frame_t *frame)
+{
+    session_t *sess = session_find_by_fd(g_server, fd);
+    if (!sess)
+        return -1;
+
+    if (frame->hdr.payload_len < 2u) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    uint8_t name_len = frame->payload[0];
+    if (name_len == 0 || name_len > PROTO_MAX_NAME ||
+        frame->hdr.payload_len < (uint32_t)(1u + name_len)) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    char name[PROTO_MAX_NAME + 1];
+    memcpy(name, &frame->payload[1], name_len);
+    name[name_len] = '\0';
+
+    iface_entry_t *e = iface_table_find(name);
+    if (!e || e->session_id != sess->session_id) {
+        proto_send_err(fd, ERR_IFACE_NOT_FOUND, NULL);
+        return 0;
+    }
+
+    printf("ash-server: session %u detaching from %s\n",
+           sess->session_id, name);
+
+    iface_entry_detach(e);
+    return proto_send_ack(fd, MSG_IFACE_DETACH_ACK, NULL, 0);
+}
+
+/*
+ * IFACE_VCAN_CREATE  (SPEC §7.4)
+ *
+ * Payload:
+ *   1B  name_len
+ *   NB  name  (e.g. "vcan0")
+ */
+static int handle_iface_vcan_create(int fd, const proto_frame_t *frame)
+{
+    if (frame->hdr.payload_len < 2u) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    uint8_t name_len = frame->payload[0];
+    if (name_len == 0 || name_len > PROTO_MAX_NAME ||
+        frame->hdr.payload_len < (uint32_t)(1u + name_len)) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    char name[PROTO_MAX_NAME + 1];
+    memcpy(name, &frame->payload[1], name_len);
+    name[name_len] = '\0';
+
+    if (vcan_create(name) < 0) {
+        fprintf(stderr, "ash-server: vcan_create(%s) failed: %s\n",
+                name, strerror(errno));
+        proto_send_err(fd, ERR_IFACE_ATTACH_FAILED, NULL);
+        return 0;
+    }
+
+    printf("ash-server: created vcan interface %s\n", name);
+    return proto_send_ack(fd, MSG_IFACE_VCAN_ACK, NULL, 0);
+}
+
+/*
+ * IFACE_VCAN_DESTROY  (SPEC §7.4)
+ *
+ * Payload:
+ *   1B  name_len
+ *   NB  name
+ */
+static int handle_iface_vcan_destroy(int fd, const proto_frame_t *frame)
+{
+    if (frame->hdr.payload_len < 2u) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    uint8_t name_len = frame->payload[0];
+    if (name_len == 0 || name_len > PROTO_MAX_NAME ||
+        frame->hdr.payload_len < (uint32_t)(1u + name_len)) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    char name[PROTO_MAX_NAME + 1];
+    memcpy(name, &frame->payload[1], name_len);
+    name[name_len] = '\0';
+
+    if (vcan_destroy(name) < 0) {
+        proto_send_err(fd, ERR_IFACE_NOT_FOUND, NULL);
+        return 0;
+    }
+
+    printf("ash-server: destroyed vcan interface %s\n", name);
+    return proto_send_ack(fd, MSG_IFACE_VCAN_ACK, NULL, 0);
+}
+
+/* -------------------------------------------------------------------------
+ * Netlink monitoring — RTMGRP_LINK events
+ * ---------------------------------------------------------------------- */
+
+/*
+ * Called from server_run() when g_netlink_fd is readable.
+ *
+ * Handles RTM_DELLINK and RTM_NEWLINK-with-IFF_UP-cleared events for
+ * attached CAN interfaces.  Sends MSG_NOTIFY_IFACE_DOWN to the owning
+ * session and cleans up the attachment.
+ */
+void iface_handle_netlink(void)
+{
+    char buf[NL_BUF_SIZE];
+    ssize_t n = recv(g_netlink_fd, buf, sizeof(buf), MSG_DONTWAIT);
+    if (n < 0)
+        return;
+
+    struct nlmsghdr *h = (struct nlmsghdr *)(void *)buf;
+    for (; NLMSG_OK(h, (unsigned int)n); h = NLMSG_NEXT(h, n)) {
+        if (h->nlmsg_type != RTM_NEWLINK && h->nlmsg_type != RTM_DELLINK)
+            continue;
+
+        struct ifinfomsg *ifi = NLMSG_DATA(h);
+        if (ifi->ifi_type != ARPHRD_CAN)
+            continue;
+
+        /* Extract interface name */
+        char ifname[IFNAMSIZ] = {0};
+        int attr_len = (int)(h->nlmsg_len - NLMSG_LENGTH(sizeof(*ifi)));
+        struct rtattr *attr = IFLA_RTA(ifi);
+        for (; RTA_OK(attr, attr_len); attr = RTA_NEXT(attr, attr_len)) {
+            if (attr->rta_type == IFLA_IFNAME) {
+                strncpy(ifname, RTA_DATA(attr), IFNAMSIZ - 1);
+                break;
+            }
+        }
+        if (ifname[0] == '\0')
+            continue;
+
+        int went_down = (h->nlmsg_type == RTM_DELLINK) ||
+                        !(ifi->ifi_flags & IFF_UP);
+        if (!went_down)
+            continue;
+
+        iface_entry_t *e = iface_table_find(ifname);
+        if (!e || e->session_id == 0)
+            continue;
+
+        printf("ash-server: interface %s went down, notifying session %u\n",
+               ifname, e->session_id);
+
+        /* NOTIFY_IFACE_DOWN payload: name_len(1) + name(N) */
+        uint8_t notif[IFNAMSIZ + 1];
+        uint8_t nlen = (uint8_t)strlen(ifname);
+        notif[0] = nlen;
+        memcpy(&notif[1], ifname, nlen);
+        proto_send_ack(e->client_fd, MSG_NOTIFY_IFACE_DOWN,
+                       notif, (uint32_t)(1u + nlen));
+
+        iface_entry_detach(e);
+    }
+}
+
+/* -------------------------------------------------------------------------
+ * Session cleanup hook
+ * ---------------------------------------------------------------------- */
+
+void iface_session_cleanup(server_t *s, uint32_t session_id)
+{
+    (void)s;
+    for (int i = 0; i < g_iface_count; i++) {
+        if (g_iface_table[i].session_id == session_id) {
+            printf("ash-server: releasing interface %s from session %u\n",
+                   g_iface_table[i].name, session_id);
+            iface_entry_detach(&g_iface_table[i]);
+        }
+    }
+}
+
+/* -------------------------------------------------------------------------
+ * Initialization and teardown
+ * ---------------------------------------------------------------------- */
+
+void iface_set_server(server_t *s)
+{
+    g_server = s;
+}
+
+int iface_init(server_t *s)
+{
+    memset(g_iface_table, 0, sizeof(g_iface_table));
+    for (int i = 0; i < MAX_IFACE_TABLE; i++) {
+        g_iface_table[i].can_fd        = -1;
+        g_iface_table[i].app_listen_fd = -1;
+        g_iface_table[i].client_fd     = -1;
+    }
+    g_iface_count = 0;
+    g_server      = s;
+
+    /* Open RTMGRP_LINK monitoring socket */
+    g_netlink_fd = socket(AF_NETLINK,
+                          SOCK_RAW | SOCK_CLOEXEC | SOCK_NONBLOCK,
+                          NETLINK_ROUTE);
+    if (g_netlink_fd < 0) {
+        perror("iface: netlink socket");
+        return -1;
+    }
+
+    struct sockaddr_nl sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.nl_family = AF_NETLINK;
+    sa.nl_groups = RTMGRP_LINK;
+    if (bind(g_netlink_fd, (struct sockaddr *)&sa, sizeof(sa)) < 0) {
+        perror("iface: netlink bind");
+        close(g_netlink_fd);
+        g_netlink_fd = -1;
+        return -1;
+    }
+
+    if (server_add_fd(s, g_netlink_fd, EPOLLIN) < 0) {
+        close(g_netlink_fd);
+        g_netlink_fd = -1;
+        return -1;
+    }
+
+    s->netlink_fd = g_netlink_fd;
+
+    iface_register_handlers();
+    return 0;
+}
+
+void iface_destroy(void)
+{
+    for (int i = 0; i < MAX_IFACE_TABLE; i++) {
+        if (g_iface_table[i].session_id != 0)
+            iface_entry_detach(&g_iface_table[i]);
+    }
+    if (g_netlink_fd >= 0) {
+        close(g_netlink_fd);
+        g_netlink_fd = -1;
+    }
+}
+
+/* -------------------------------------------------------------------------
+ * Handler registration
+ * ---------------------------------------------------------------------- */
+
+void iface_register_handlers(void)
+{
+    proto_register_handler(MSG_IFACE_LIST,         handle_iface_list);
+    proto_register_handler(MSG_IFACE_ATTACH,       handle_iface_attach);
+    proto_register_handler(MSG_IFACE_DETACH,       handle_iface_detach);
+    proto_register_handler(MSG_IFACE_VCAN_CREATE,  handle_iface_vcan_create);
+    proto_register_handler(MSG_IFACE_VCAN_DESTROY, handle_iface_vcan_destroy);
+}

--- a/server/iface.h
+++ b/server/iface.h
@@ -1,0 +1,49 @@
+#ifndef ASH_SERVER_IFACE_H
+#define ASH_SERVER_IFACE_H
+
+#include "server.h"
+#include <stdint.h>
+
+/* -------------------------------------------------------------------------
+ * Interface management module (SPEC §7)
+ *
+ * Handles CAN interface discovery, attachment, detachment, and virtual
+ * interface creation/destruction via Linux SocketCAN and netlink.
+ * ---------------------------------------------------------------------- */
+
+/* Set the server pointer (called before iface_init). */
+void iface_set_server(server_t *s);
+
+/*
+ * Open the RTMGRP_LINK monitoring netlink socket and register it with the
+ * server's epoll instance.  Also registers message handlers.
+ *
+ * Returns 0 on success, -1 on error.
+ */
+int iface_init(server_t *s);
+
+/*
+ * Close all attached CAN sockets and the monitoring netlink socket.
+ * Called from server_destroy().
+ */
+void iface_destroy(void);
+
+/*
+ * Register IFACE_* message handlers with the dispatch table.
+ * Called from iface_init().
+ */
+void iface_register_handlers(void);
+
+/*
+ * Process a pending netlink event on the monitoring socket.
+ * Called from server_run() when the netlink fd is readable.
+ */
+void iface_handle_netlink(void);
+
+/*
+ * Release all interfaces owned by the given session.
+ * Called from session_cleanup() before zeroing session state.
+ */
+void iface_session_cleanup(server_t *s, uint32_t session_id);
+
+#endif /* ASH_SERVER_IFACE_H */

--- a/server/server.c
+++ b/server/server.c
@@ -1,6 +1,7 @@
 #include "server.h"
 #include "proto.h"
 #include "session.h"
+#include "iface.h"
 
 #include <sys/epoll.h>
 #include <sys/signalfd.h>
@@ -113,6 +114,7 @@ int server_init(server_t *s, uint16_t port, const char *storage_dir)
     s->epoll_fd   = -1;
     s->listen_fd  = -1;
     s->signal_fd  = -1;
+    s->netlink_fd = -1;
     s->port       = port;
     s->storage_dir = storage_dir;
 
@@ -185,6 +187,10 @@ int server_init(server_t *s, uint16_t port, const char *storage_dir)
     session_set_server(s);
     session_register_handlers();
 
+    /* --- Interface module --- */
+    if (iface_init(s) < 0)
+        return -1;
+
     printf("ash-server listening on port %u\n", (unsigned)port);
     return 0;
 }
@@ -232,6 +238,9 @@ void server_run(server_t *s)
                     }
                     session_add(s, cfd);
                 }
+
+            } else if (fd == s->netlink_fd) {
+                iface_handle_netlink();
 
             } else {
                 /* Check if this fd is a keep-alive timerfd */
@@ -344,6 +353,8 @@ void server_destroy(server_t *s)
         s->sessions[i].fd = -1;
     }
 
+    iface_destroy();
+
     if (s->listen_fd >= 0) {
         close(s->listen_fd);
         s->listen_fd = -1;
@@ -351,6 +362,9 @@ void server_destroy(server_t *s)
     if (s->signal_fd >= 0) {
         close(s->signal_fd);
         s->signal_fd = -1;
+    }
+    if (s->netlink_fd >= 0) {
+        s->netlink_fd = -1;   /* already closed by iface_destroy() */
     }
     if (s->epoll_fd >= 0) {
         close(s->epoll_fd);

--- a/server/server.h
+++ b/server/server.h
@@ -20,6 +20,7 @@ typedef struct {
     int         epoll_fd;
     int         listen_fd;
     int         signal_fd;
+    int         netlink_fd;   /* RTMGRP_LINK monitoring socket (-1 if unused) */
     const char *storage_dir;
     uint16_t    port;
     session_t   sessions[MAX_SESSIONS];

--- a/server/session.c
+++ b/server/session.c
@@ -1,5 +1,6 @@
 #include "session.h"
 #include "proto.h"
+#include "iface.h"
 
 #include "ash/proto.h"
 
@@ -69,8 +70,8 @@ void session_arm_timer(session_t *sess)
 
 void session_cleanup(server_t *s, session_t *sess)
 {
-    (void)s;
-    /* Future: release owned signals, detach interfaces */
+    if (sess->session_id != 0)
+        iface_session_cleanup(s, sess->session_id);
     sess->session_id = 0;
     memset(sess->client_name, 0, sizeof(sess->client_name));
 }

--- a/tools/test_client.py
+++ b/tools/test_client.py
@@ -8,9 +8,13 @@ Usage:
 Default host/port: 127.0.0.1:4000
 
 Tests 1-7 run automatically.
+Tests 10-16 (CAN interface management) run automatically; the server must have
+CAP_NET_ADMIN (root) to create/destroy vcan interfaces.
 Test 8 (graceful server shutdown) requires manually stopping the server and
 must be requested with --test 8.
 Test 9 (keep-alive timeout) waits 30+ seconds and must be requested with --test 9.
+Test 17 (NOTIFY_IFACE_DOWN) requires manually deleting vcan99 while the test
+waits, and must be requested with --test 17.
 """
 
 import argparse
@@ -25,14 +29,28 @@ PROTO_VERSION           = 0x0001
 PROTO_HEADER_SIZE       = 8
 PROTO_MAX_PAYLOAD       = 65535
 
+# Session management
 MSG_SESSION_INIT        = 0x0001
 MSG_SESSION_KEEPALIVE   = 0x0002
 MSG_SESSION_CLOSE       = 0x0003
 MSG_SESSION_INIT_ACK    = 0x8001
 MSG_SESSION_CLOSE_ACK   = 0x8003
-MSG_ERR                 = 0xFFFF
 MSG_NOTIFY_SERVER_CLOSE = 0x9003
+MSG_ERR                 = 0xFFFF
 
+# Interface management (SPEC §7)
+MSG_IFACE_LIST          = 0x0010
+MSG_IFACE_ATTACH        = 0x0011
+MSG_IFACE_DETACH        = 0x0012
+MSG_IFACE_VCAN_CREATE   = 0x0013
+MSG_IFACE_VCAN_DESTROY  = 0x0014
+MSG_IFACE_LIST_RESP     = 0x8010
+MSG_IFACE_ATTACH_ACK    = 0x8011
+MSG_IFACE_DETACH_ACK    = 0x8012
+MSG_IFACE_VCAN_ACK      = 0x8013
+MSG_NOTIFY_IFACE_DOWN   = 0x9002
+
+# Session error codes
 ERR_PROTOCOL_VERSION     = 0x0001
 ERR_UNKNOWN_MESSAGE_TYPE = 0x0002
 ERR_PAYLOAD_TOO_LARGE    = 0x0003
@@ -40,7 +58,20 @@ ERR_NOT_IN_SESSION       = 0x0004
 ERR_ALREADY_IN_SESSION   = 0x0005
 ERR_NAME_TOO_LONG        = 0x0006
 
+# Interface error codes
+ERR_IFACE_NOT_FOUND         = 0x0010
+ERR_IFACE_ALREADY_ATTACHED  = 0x0011
+ERR_IFACE_ATTACH_FAILED     = 0x0012
+
+# Interface states (in IFACE_LIST_RESP)
+IFACE_STATE_AVAILABLE       = 0x01
+IFACE_STATE_ATTACHED_THIS   = 0x02
+IFACE_STATE_ATTACHED_OTHER  = 0x03
+
 KEEPALIVE_TIMEOUT_SEC    = 30
+
+# vcan interface name used by tests 10-17
+TEST_VCAN = 'vcan99'
 
 # ── Frame helpers ─────────────────────────────────────────────────────────────
 
@@ -104,7 +135,17 @@ MSG_NAMES = {
     0x0003: 'SESSION_CLOSE',
     0x8001: 'SESSION_INIT_ACK',
     0x8003: 'SESSION_CLOSE_ACK',
+    0x9002: 'NOTIFY_IFACE_DOWN',
     0x9003: 'NOTIFY_SERVER_CLOSE',
+    0x0010: 'IFACE_LIST',
+    0x0011: 'IFACE_ATTACH',
+    0x0012: 'IFACE_DETACH',
+    0x0013: 'IFACE_VCAN_CREATE',
+    0x0014: 'IFACE_VCAN_DESTROY',
+    0x8010: 'IFACE_LIST_RESP',
+    0x8011: 'IFACE_ATTACH_ACK',
+    0x8012: 'IFACE_DETACH_ACK',
+    0x8013: 'IFACE_VCAN_ACK',
     0xFFFF: 'MSG_ERR',
 }
 
@@ -115,6 +156,9 @@ ERR_NAMES = {
     0x0004: 'ERR_NOT_IN_SESSION',
     0x0005: 'ERR_ALREADY_IN_SESSION',
     0x0006: 'ERR_NAME_TOO_LONG',
+    0x0010: 'ERR_IFACE_NOT_FOUND',
+    0x0011: 'ERR_IFACE_ALREADY_ATTACHED',
+    0x0012: 'ERR_IFACE_ATTACH_FAILED',
 }
 
 def fmt_type(t):
@@ -356,21 +400,451 @@ def test_keepalive_timeout(host, port):
               f'(actual: {elapsed:.1f} s)')
 
 
+# ── Interface management helpers ──────────────────────────────────────────────
+
+def make_iface_vcan_create(name):
+    n = name.encode()
+    return make_frame(PROTO_VERSION, MSG_IFACE_VCAN_CREATE, bytes([len(n)]) + n)
+
+
+def make_iface_vcan_destroy(name):
+    n = name.encode()
+    return make_frame(PROTO_VERSION, MSG_IFACE_VCAN_DESTROY, bytes([len(n)]) + n)
+
+
+def make_iface_list():
+    return make_frame(PROTO_VERSION, MSG_IFACE_LIST)
+
+
+def make_iface_attach(name, mode=0x01, bitrate=0, filters=None):
+    """Build an IFACE_ATTACH frame.
+
+    mode:    0x01=CAN2.0A  0x02=CAN2.0B  0x03=CAN FD
+    bitrate: bps; 0 means do not reconfigure
+    filters: list of (can_id, mask) tuples; empty = promiscuous
+    """
+    n = name.encode()
+    payload = bytes([len(n)]) + n
+    payload += bytes([mode])
+    payload += struct.pack('>I', bitrate)
+    filters = filters or []
+    payload += bytes([len(filters)])
+    for can_id, mask in filters:
+        payload += struct.pack('>II', can_id, mask)
+    return make_frame(PROTO_VERSION, MSG_IFACE_ATTACH, payload)
+
+
+def make_iface_detach(name):
+    n = name.encode()
+    return make_frame(PROTO_VERSION, MSG_IFACE_DETACH, bytes([len(n)]) + n)
+
+
+def parse_iface_list_resp(payload):
+    """Parse IFACE_LIST_RESP → list of (name, state) tuples."""
+    if not payload:
+        return []
+    pos = 0
+    count = payload[pos]; pos += 1
+    result = []
+    for _ in range(count):
+        if pos >= len(payload):
+            break
+        nlen = payload[pos]; pos += 1
+        name = payload[pos:pos + nlen].decode(errors='replace'); pos += nlen
+        state = payload[pos]; pos += 1
+        result.append((name, state))
+    return result
+
+
+def parse_attach_ack(payload):
+    """Parse IFACE_ATTACH_ACK → app_port (u16 big-endian)."""
+    if len(payload) < 2:
+        return None
+    return struct.unpack('>H', payload[:2])[0]
+
+
+def open_session(host, port, name='test-client'):
+    """Connect, send SESSION_INIT, return (socket, session_id) or (None, None)."""
+    s = socket.create_connection((host, port), timeout=5)
+    s.sendall(make_session_init(name))
+    frame = recv_frame(s)
+    if frame is None or frame[1] != MSG_SESSION_INIT_ACK:
+        s.close()
+        return None, None
+    return s, parse_session_id(frame[2])
+
+
+# ── Interface management tests (SPEC §7) ──────────────────────────────────────
+
+def test_iface_vcan_create(host, port):
+    """Test 10 — IFACE_VCAN_CREATE creates vcan99; IFACE_VCAN_DESTROY removes it."""
+    print(f'\n[10] IFACE_VCAN_CREATE {TEST_VCAN} — expect IFACE_VCAN_ACK; destroy — expect IFACE_VCAN_ACK')
+    with socket.create_connection((host, port), timeout=5) as s:
+        s.sendall(make_session_init('vcan-create-test'))
+        if recv_frame(s) is None:
+            check(False, 'could not establish session (prerequisite failed)')
+            return
+
+        # Create
+        s.sendall(make_iface_vcan_create(TEST_VCAN))
+        frame = recv_frame(s)
+        print_response(frame)
+        if not check(frame is not None, 'received a response to VCAN_CREATE'):
+            return
+        _, msg_type, _ = frame
+        ok = check(msg_type == MSG_IFACE_VCAN_ACK,
+                   f'response is IFACE_VCAN_ACK (got {fmt_type(msg_type)})')
+
+        # Destroy (cleanup regardless of create result)
+        s.sendall(make_iface_vcan_destroy(TEST_VCAN))
+        frame2 = recv_frame(s)
+        print_response(frame2)
+        if ok:
+            if not check(frame2 is not None, 'received a response to VCAN_DESTROY'):
+                return
+            _, msg_type2, _ = frame2
+            check(msg_type2 == MSG_IFACE_VCAN_ACK,
+                  f'response is IFACE_VCAN_ACK (got {fmt_type(msg_type2)})')
+
+
+def test_iface_list(host, port):
+    """Test 11 — IFACE_LIST_RESP contains vcan99 as available after creation."""
+    print(f'\n[11] IFACE_LIST — expect {TEST_VCAN} listed as available (state=0x01)')
+    with socket.create_connection((host, port), timeout=5) as s:
+        s.sendall(make_session_init('iface-list-test'))
+        if recv_frame(s) is None:
+            check(False, 'could not establish session (prerequisite failed)')
+            return
+
+        # Create vcan
+        s.sendall(make_iface_vcan_create(TEST_VCAN))
+        frame = recv_frame(s)
+        if frame is None or frame[1] != MSG_IFACE_VCAN_ACK:
+            check(False, f'VCAN_CREATE prerequisite failed ({fmt_type(frame[1]) if frame else "no response"})')
+            return
+
+        try:
+            # List
+            s.sendall(make_iface_list())
+            frame = recv_frame(s)
+            print_response(frame)
+            if not check(frame is not None, 'received a response'):
+                return
+            _, msg_type, payload = frame
+            if not check(msg_type == MSG_IFACE_LIST_RESP,
+                         f'response is IFACE_LIST_RESP (got {fmt_type(msg_type)})'):
+                return
+            ifaces = parse_iface_list_resp(payload)
+            names = [n for n, _ in ifaces]
+            print(f'  interfaces: {ifaces}')
+            if check(TEST_VCAN in names, f'{TEST_VCAN} is present in list'):
+                state = dict(ifaces)[TEST_VCAN]
+                check(state == IFACE_STATE_AVAILABLE,
+                      f'{TEST_VCAN} state is AVAILABLE (0x01) (got 0x{state:02X})')
+        finally:
+            s.sendall(make_iface_vcan_destroy(TEST_VCAN))
+            recv_frame(s)
+
+
+def test_iface_attach(host, port):
+    """Test 12 — IFACE_ATTACH returns a valid app-plane port; list shows attached-this."""
+    print(f'\n[12] IFACE_ATTACH {TEST_VCAN} — expect IFACE_ATTACH_ACK with non-zero port; list shows attached-this')
+    with socket.create_connection((host, port), timeout=5) as s:
+        s.sendall(make_session_init('iface-attach-test'))
+        if recv_frame(s) is None:
+            check(False, 'could not establish session (prerequisite failed)')
+            return
+
+        s.sendall(make_iface_vcan_create(TEST_VCAN))
+        if recv_frame(s) is None:
+            check(False, 'VCAN_CREATE prerequisite failed')
+            return
+
+        try:
+            s.sendall(make_iface_attach(TEST_VCAN))
+            frame = recv_frame(s)
+            print_response(frame)
+            if not check(frame is not None, 'received a response to IFACE_ATTACH'):
+                return
+            _, msg_type, payload = frame
+            if not check(msg_type == MSG_IFACE_ATTACH_ACK,
+                         f'response is IFACE_ATTACH_ACK (got {fmt_type(msg_type)})'):
+                return
+            port_val = parse_attach_ack(payload)
+            check(port_val is not None and port_val != 0,
+                  f'app-plane port is non-zero (got {port_val})')
+
+            # Verify list shows attached-this
+            s.sendall(make_iface_list())
+            frame2 = recv_frame(s)
+            if frame2 and frame2[1] == MSG_IFACE_LIST_RESP:
+                ifaces = parse_iface_list_resp(frame2[2])
+                state = dict(ifaces).get(TEST_VCAN)
+                check(state == IFACE_STATE_ATTACHED_THIS,
+                      f'list shows {TEST_VCAN} as ATTACHED_THIS (0x02) (got 0x{state:02X})'
+                      if state is not None else f'{TEST_VCAN} missing from list')
+        finally:
+            s.sendall(make_iface_vcan_destroy(TEST_VCAN))
+            recv_frame(s)
+
+
+def test_iface_already_attached(host, port):
+    """Test 13 — Second IFACE_ATTACH (same or different session) → ERR_IFACE_ALREADY_ATTACHED; list shows attached-other from second session."""
+    print(f'\n[13] Duplicate IFACE_ATTACH — expect ERR_IFACE_ALREADY_ATTACHED; list shows attached-other from second session')
+    with socket.create_connection((host, port), timeout=5) as s1, \
+         socket.create_connection((host, port), timeout=5) as s2:
+        s1.sendall(make_session_init('attach-owner'))
+        if recv_frame(s1) is None:
+            check(False, 'could not establish session 1 (prerequisite failed)')
+            return
+        s2.sendall(make_session_init('attach-thief'))
+        if recv_frame(s2) is None:
+            check(False, 'could not establish session 2 (prerequisite failed)')
+            return
+
+        s1.sendall(make_iface_vcan_create(TEST_VCAN))
+        if recv_frame(s1) is None:
+            check(False, f'VCAN_CREATE prerequisite failed')
+            return
+
+        try:
+            # First attach (from s1) — should succeed
+            s1.sendall(make_iface_attach(TEST_VCAN))
+            frame = recv_frame(s1)
+            if frame is None or frame[1] != MSG_IFACE_ATTACH_ACK:
+                check(False, 'first attach prerequisite failed')
+                return
+
+            # Second attach (from s2) — should fail
+            s2.sendall(make_iface_attach(TEST_VCAN))
+            frame2 = recv_frame(s2)
+            print_response(frame2)
+            if not check(frame2 is not None, 'received a response to second IFACE_ATTACH'):
+                return
+            _, msg_type, payload = frame2
+            check(msg_type == MSG_ERR,
+                  f'response is MSG_ERR (got {fmt_type(msg_type)})')
+            code, _ = decode_err(payload)
+            check(code == ERR_IFACE_ALREADY_ATTACHED,
+                  f'err_code is ERR_IFACE_ALREADY_ATTACHED (got {fmt_err(code)})')
+
+            # Second session's IFACE_LIST should show attached-other
+            s2.sendall(make_iface_list())
+            frame3 = recv_frame(s2)
+            if frame3 and frame3[1] == MSG_IFACE_LIST_RESP:
+                ifaces = parse_iface_list_resp(frame3[2])
+                state = dict(ifaces).get(TEST_VCAN)
+                check(state == IFACE_STATE_ATTACHED_OTHER,
+                      f'list (from s2) shows {TEST_VCAN} as ATTACHED_OTHER (0x03) (got 0x{state:02X})'
+                      if state is not None else f'{TEST_VCAN} missing from list')
+        finally:
+            s1.sendall(make_iface_vcan_destroy(TEST_VCAN))
+            recv_frame(s1)
+
+
+def test_iface_detach(host, port):
+    """Test 14 — IFACE_DETACH releases interface; subsequent attach by another session succeeds."""
+    print(f'\n[14] IFACE_DETACH — expect IFACE_DETACH_ACK; re-attach by second session succeeds')
+    with socket.create_connection((host, port), timeout=5) as s1, \
+         socket.create_connection((host, port), timeout=5) as s2:
+        s1.sendall(make_session_init('detach-owner'))
+        if recv_frame(s1) is None:
+            check(False, 'could not establish session 1 (prerequisite failed)')
+            return
+        s2.sendall(make_session_init('detach-reattach'))
+        if recv_frame(s2) is None:
+            check(False, 'could not establish session 2 (prerequisite failed)')
+            return
+
+        s1.sendall(make_iface_vcan_create(TEST_VCAN))
+        if recv_frame(s1) is None:
+            check(False, 'VCAN_CREATE prerequisite failed')
+            return
+
+        try:
+            s1.sendall(make_iface_attach(TEST_VCAN))
+            if recv_frame(s1) is None:
+                check(False, 'IFACE_ATTACH prerequisite failed')
+                return
+
+            # Detach
+            s1.sendall(make_iface_detach(TEST_VCAN))
+            frame = recv_frame(s1)
+            print_response(frame)
+            if not check(frame is not None, 'received a response to IFACE_DETACH'):
+                return
+            _, msg_type, _ = frame
+            check(msg_type == MSG_IFACE_DETACH_ACK,
+                  f'response is IFACE_DETACH_ACK (got {fmt_type(msg_type)})')
+
+            # Re-attach from second session
+            s2.sendall(make_iface_attach(TEST_VCAN))
+            frame2 = recv_frame(s2)
+            print_response(frame2)
+            if not check(frame2 is not None, 'received response to re-attach'):
+                return
+            _, msg_type2, payload2 = frame2
+            check(msg_type2 == MSG_IFACE_ATTACH_ACK,
+                  f're-attach succeeds (got {fmt_type(msg_type2)})')
+            if msg_type2 == MSG_IFACE_ATTACH_ACK:
+                port_val = parse_attach_ack(payload2)
+                check(port_val is not None and port_val != 0,
+                      f're-attach app-plane port is non-zero (got {port_val})')
+        finally:
+            s1.sendall(make_iface_vcan_destroy(TEST_VCAN))
+            recv_frame(s1)
+
+
+def test_session_close_releases_iface(host, port):
+    """Test 15 — Session close (without explicit IFACE_DETACH) releases the interface."""
+    print(f'\n[15] Session close releases attached interface — second session can re-attach')
+    with socket.create_connection((host, port), timeout=5) as s1:
+        s1.sendall(make_session_init('close-owner'))
+        if recv_frame(s1) is None:
+            check(False, 'could not establish session 1 (prerequisite failed)')
+            return
+
+        s1.sendall(make_iface_vcan_create(TEST_VCAN))
+        if recv_frame(s1) is None:
+            check(False, 'VCAN_CREATE prerequisite failed')
+            return
+
+        s1.sendall(make_iface_attach(TEST_VCAN))
+        if recv_frame(s1) is None:
+            check(False, 'IFACE_ATTACH prerequisite failed')
+            return
+
+        # Close session (server must clean up the attachment)
+        s1.sendall(make_frame(PROTO_VERSION, MSG_SESSION_CLOSE))
+        frame = recv_frame(s1)
+        if not check(frame is not None and frame[1] == MSG_SESSION_CLOSE_ACK,
+                     'SESSION_CLOSE_ACK received'):
+            return
+
+    # New session: attach should now succeed
+    try:
+        with socket.create_connection((host, port), timeout=5) as s2:
+            s2.sendall(make_session_init('close-reattach'))
+            if recv_frame(s2) is None:
+                check(False, 'could not establish session 2')
+                return
+            s2.sendall(make_iface_attach(TEST_VCAN))
+            frame2 = recv_frame(s2)
+            print_response(frame2)
+            if not check(frame2 is not None, 'received response to re-attach'):
+                return
+            _, msg_type, _ = frame2
+            check(msg_type == MSG_IFACE_ATTACH_ACK,
+                  f'session-close released interface; re-attach succeeds (got {fmt_type(msg_type)})')
+    finally:
+        with socket.create_connection((host, port), timeout=5) as cleanup:
+            cleanup.sendall(make_session_init('cleanup'))
+            recv_frame(cleanup)
+            cleanup.sendall(make_iface_vcan_destroy(TEST_VCAN))
+            recv_frame(cleanup)
+
+
+def test_iface_vcan_destroy(host, port):
+    """Test 16 — IFACE_VCAN_DESTROY removes the interface (not in subsequent IFACE_LIST)."""
+    print(f'\n[16] IFACE_VCAN_DESTROY {TEST_VCAN} — interface absent from subsequent IFACE_LIST')
+    with socket.create_connection((host, port), timeout=5) as s:
+        s.sendall(make_session_init('vcan-destroy-test'))
+        if recv_frame(s) is None:
+            check(False, 'could not establish session (prerequisite failed)')
+            return
+
+        s.sendall(make_iface_vcan_create(TEST_VCAN))
+        if recv_frame(s) is None:
+            check(False, 'VCAN_CREATE prerequisite failed')
+            return
+
+        s.sendall(make_iface_vcan_destroy(TEST_VCAN))
+        frame = recv_frame(s)
+        print_response(frame)
+        if not check(frame is not None, 'received a response to VCAN_DESTROY'):
+            return
+        _, msg_type, _ = frame
+        if not check(msg_type == MSG_IFACE_VCAN_ACK,
+                     f'response is IFACE_VCAN_ACK (got {fmt_type(msg_type)})'):
+            return
+
+        s.sendall(make_iface_list())
+        frame2 = recv_frame(s)
+        if frame2 and frame2[1] == MSG_IFACE_LIST_RESP:
+            ifaces = parse_iface_list_resp(frame2[2])
+            names = [n for n, _ in ifaces]
+            check(TEST_VCAN not in names,
+                  f'{TEST_VCAN} absent from IFACE_LIST after destroy (got {names})')
+
+
+def test_notify_iface_down(host, port):
+    """
+    Test 17 — NOTIFY_IFACE_DOWN emitted when an attached interface is deleted.
+    Attach to vcan99, then manually run:  sudo ip link delete vcan99
+    The server should send NOTIFY_IFACE_DOWN to this session.
+    """
+    print(f'\n[17] NOTIFY_IFACE_DOWN — attach to {TEST_VCAN}, then run: sudo ip link delete {TEST_VCAN}')
+    print(f'     Waiting up to 60 s for NOTIFY_IFACE_DOWN … (Ctrl-C to skip)')
+    try:
+        with socket.create_connection((host, port), timeout=60) as s:
+            s.sendall(make_session_init('notify-down-watcher'))
+            if recv_frame(s) is None:
+                check(False, 'could not establish session')
+                return
+
+            s.sendall(make_iface_vcan_create(TEST_VCAN))
+            frame = recv_frame(s)
+            if frame is None or frame[1] != MSG_IFACE_VCAN_ACK:
+                check(False, 'VCAN_CREATE prerequisite failed')
+                return
+
+            s.sendall(make_iface_attach(TEST_VCAN))
+            frame = recv_frame(s)
+            if frame is None or frame[1] != MSG_IFACE_ATTACH_ACK:
+                check(False, 'IFACE_ATTACH prerequisite failed')
+                return
+
+            print(f'  session attached to {TEST_VCAN}; now run: sudo ip link delete {TEST_VCAN}')
+            s.settimeout(60)
+            frame = recv_frame(s)
+            print_response(frame)
+            if not check(frame is not None, 'received a notification frame'):
+                return
+            _, msg_type, payload = frame
+            check(msg_type == MSG_NOTIFY_IFACE_DOWN,
+                  f'received NOTIFY_IFACE_DOWN (got {fmt_type(msg_type)})')
+            if msg_type == MSG_NOTIFY_IFACE_DOWN and payload:
+                nlen = payload[0]
+                name = payload[1:1 + nlen].decode(errors='replace')
+                check(name == TEST_VCAN,
+                      f'notification names {TEST_VCAN} (got {name!r})')
+    except KeyboardInterrupt:
+        print('  [skipped]')
+
+
 # ── Entry point ───────────────────────────────────────────────────────────────
 
 TESTS = [
-    test_bad_version,           # 1
-    test_payload_too_large,     # 2
-    test_unknown_type,          # 3
-    test_session_init,          # 4
-    test_already_in_session,    # 5
-    test_not_in_session,        # 6
-    test_session_close,         # 7
-    test_server_close,          # 8  — interactive
-    test_keepalive_timeout,     # 9  — slow (30+ s)
+    test_bad_version,                   # 1
+    test_payload_too_large,             # 2
+    test_unknown_type,                  # 3
+    test_session_init,                  # 4
+    test_already_in_session,            # 5
+    test_not_in_session,                # 6
+    test_session_close,                 # 7
+    test_server_close,                  # 8  — interactive
+    test_keepalive_timeout,             # 9  — slow (30+ s)
+    test_iface_vcan_create,             # 10
+    test_iface_list,                    # 11
+    test_iface_attach,                  # 12
+    test_iface_already_attached,        # 13
+    test_iface_detach,                  # 14
+    test_session_close_releases_iface,  # 15
+    test_iface_vcan_destroy,            # 16
+    test_notify_iface_down,             # 17 — interactive
 ]
 
-AUTO_TESTS = TESTS[:7]   # 1-7 run unattended
+AUTO_TESTS = TESTS[:7] + TESTS[9:16]   # 1-7 and 10-16 run unattended
 
 
 def main():
@@ -397,8 +871,9 @@ def main():
     else:
         for fn in AUTO_TESTS:
             run(fn)
-        print('\n[8] Graceful shutdown  — run with --test 8')
-        print('[9] Keep-alive timeout — run with --test 9 (takes 35 s)')
+        print('\n[8]  Graceful shutdown    — run with --test 8')
+        print('[9]  Keep-alive timeout  — run with --test 9 (takes 35 s)')
+        print('[17] NOTIFY_IFACE_DOWN   — run with --test 17 (requires manual ip link delete)')
 
     print()
 


### PR DESCRIPTION
## Summary

- **IFACE_LIST**: enumerate CAN interfaces via `RTM_GETLINK` netlink dump, returning name and attachment state (available / attached-this / attached-other) per SPEC §7.1
- **IFACE_ATTACH**: open `AF_CAN`/`SOCK_RAW` socket, configure CAN FD mode and RX filters, bind to interface, create ephemeral app-plane TCP listener; respond with `IFACE_ATTACH_ACK` carrying the 2-byte port per SPEC §7.2
- **IFACE_DETACH**: release SocketCAN socket and app-plane listener for the calling session per SPEC §7.3
- **IFACE_VCAN_CREATE / IFACE_VCAN_DESTROY**: create and destroy `vcan` interfaces via `NETLINK_ROUTE` `RTM_NEWLINK`/`RTM_DELLINK` (no shell) per SPEC §7.4
- Bitrate configuration via netlink `IFLA_CAN_BITTIMING` when a non-zero bitrate is requested
- `RTMGRP_LINK` monitoring socket (added to epoll) emits `NOTIFY_IFACE_DOWN` and cleans up attachment on unexpected interface down/deletion
- `session_cleanup()` now calls `iface_session_cleanup()` to release interfaces owned by a closing session
- `server_t` gains a `netlink_fd` field; `server_run()` routes netlink events to `iface_handle_netlink()`
- Exclusive attachment enforced: `ERR_IFACE_ALREADY_ATTACHED` returned if another session holds the interface

## Test plan

- [x] Build passes cleanly with `-Wall -Wextra -Werror`
- [x] `IFACE_LIST` returns correct interface list and states (available, attached-this, attached-other)
- [x] `IFACE_VCAN_CREATE vcan0` creates the interface (visible via `ip link`)
- [x] `IFACE_ATTACH vcan0` succeeds and returns a valid app-plane port
- [x] Second `IFACE_ATTACH vcan0` from same or different session returns `ERR_IFACE_ALREADY_ATTACHED`
- [x] `IFACE_DETACH vcan0` releases the interface; subsequent attach succeeds
- [x] Session close releases attached interface
- [x] `IFACE_VCAN_DESTROY vcan0` removes the interface
- [x] `ip link delete vcan0` while attached triggers `NOTIFY_IFACE_DOWN` to owning session

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)