### PR TITLE
#7: implement Signal/PDU/Frame definition store

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ add_compile_options($<$<CONFIG:Debug>:-Wall>
 include_directories(include)
 
 # Server
-add_executable(ash-server server/main.c server/server.c server/proto.c server/session.c server/iface.c)
+add_executable(ash-server server/main.c server/server.c server/proto.c server/session.c server/iface.c server/def.c)
 target_compile_definitions(ash-server PRIVATE _GNU_SOURCE)
 
 # Client library

--- a/server/def.c
+++ b/server/def.c
@@ -1,0 +1,603 @@
+#include "def.h"
+#include "proto.h"
+
+#include "ash/proto.h"
+
+#include <stdint.h>
+#include <string.h>
+#include <stdio.h>
+
+/* -------------------------------------------------------------------------
+ * Store limits
+ * ---------------------------------------------------------------------- */
+
+#define MAX_SIGNALS  512
+#define MAX_PDUS     256
+#define MAX_FRAMES   128
+
+#define MAX_SIGNALS_PER_PDU   32
+#define MAX_PDUS_PER_FRAME     8
+
+/* -------------------------------------------------------------------------
+ * In-memory definition types
+ * ---------------------------------------------------------------------- */
+
+typedef struct {
+    char    sig_name[PROTO_MAX_NAME + 1];
+    uint8_t start_bit;
+} pdu_signal_mapping_t;
+
+typedef struct {
+    char    pdu_name[PROTO_MAX_NAME + 1];
+    uint8_t byte_offset;
+} frame_pdu_mapping_t;
+
+typedef struct {
+    char     name[PROTO_MAX_NAME + 1];
+    uint8_t  data_type;
+    uint8_t  byte_order;
+    uint8_t  bit_length;
+    double   scale;
+    double   offset_val;
+    double   min_val;
+    double   max_val;
+} signal_def_t;
+
+typedef struct {
+    char                 name[PROTO_MAX_NAME + 1];
+    uint8_t              length;
+    uint8_t              signal_count;
+    pdu_signal_mapping_t signals[MAX_SIGNALS_PER_PDU];
+} pdu_def_t;
+
+typedef struct {
+    char                name[PROTO_MAX_NAME + 1];
+    uint32_t            can_id;
+    uint8_t             id_type;
+    uint8_t             dlc;
+    uint16_t            tx_period;
+    uint8_t             pdu_count;
+    frame_pdu_mapping_t pdus[MAX_PDUS_PER_FRAME];
+} frame_def_t;
+
+/* -------------------------------------------------------------------------
+ * Global stores
+ * ---------------------------------------------------------------------- */
+
+static signal_def_t g_signals[MAX_SIGNALS];
+static int          g_signal_count;
+
+static pdu_def_t    g_pdus[MAX_PDUS];
+static int          g_pdu_count;
+
+static frame_def_t  g_frames[MAX_FRAMES];
+static int          g_frame_count;
+
+/* -------------------------------------------------------------------------
+ * Def type identifiers  (wire values per SPEC §6.4)
+ * ---------------------------------------------------------------------- */
+
+#define DEF_TYPE_SIGNAL  0x01u
+#define DEF_TYPE_PDU     0x02u
+#define DEF_TYPE_FRAME   0x03u
+
+/* -------------------------------------------------------------------------
+ * Lookup helpers
+ * ---------------------------------------------------------------------- */
+
+static signal_def_t *signal_find(const char *name)
+{
+    for (int i = 0; i < g_signal_count; i++) {
+        if (strcmp(g_signals[i].name, name) == 0)
+            return &g_signals[i];
+    }
+    return NULL;
+}
+
+static pdu_def_t *pdu_find(const char *name)
+{
+    for (int i = 0; i < g_pdu_count; i++) {
+        if (strcmp(g_pdus[i].name, name) == 0)
+            return &g_pdus[i];
+    }
+    return NULL;
+}
+
+static frame_def_t *frame_find(const char *name)
+{
+    for (int i = 0; i < g_frame_count; i++) {
+        if (strcmp(g_frames[i].name, name) == 0)
+            return &g_frames[i];
+    }
+    return NULL;
+}
+
+/*
+ * Returns the wire DEF_TYPE_* constant if `name` exists in any table,
+ * or 0 if the name is not defined.
+ */
+static uint8_t namespace_type(const char *name)
+{
+    if (signal_find(name)) return DEF_TYPE_SIGNAL;
+    if (pdu_find(name))    return DEF_TYPE_PDU;
+    if (frame_find(name))  return DEF_TYPE_FRAME;
+    return 0;
+}
+
+/* Returns 1 if any PDU references `sig_name`. */
+static int signal_has_dependents(const char *sig_name)
+{
+    for (int i = 0; i < g_pdu_count; i++) {
+        for (int j = 0; j < (int)g_pdus[i].signal_count; j++) {
+            if (strcmp(g_pdus[i].signals[j].sig_name, sig_name) == 0)
+                return 1;
+        }
+    }
+    return 0;
+}
+
+/* Returns 1 if any frame references `pdu_name`. */
+static int pdu_has_dependents(const char *pdu_name)
+{
+    for (int i = 0; i < g_frame_count; i++) {
+        for (int j = 0; j < (int)g_frames[i].pdu_count; j++) {
+            if (strcmp(g_frames[i].pdus[j].pdu_name, pdu_name) == 0)
+                return 1;
+        }
+    }
+    return 0;
+}
+
+/* -------------------------------------------------------------------------
+ * Wire read helper for IEEE 754 doubles stored big-endian
+ * ---------------------------------------------------------------------- */
+
+static double read_be_double(const uint8_t *p)
+{
+    uint64_t raw = ((uint64_t)p[0] << 56) | ((uint64_t)p[1] << 48)
+                 | ((uint64_t)p[2] << 40) | ((uint64_t)p[3] << 32)
+                 | ((uint64_t)p[4] << 24) | ((uint64_t)p[5] << 16)
+                 | ((uint64_t)p[6] <<  8) |  (uint64_t)p[7];
+    double d;
+    memcpy(&d, &raw, sizeof(d));
+    return d;
+}
+
+/* -------------------------------------------------------------------------
+ * DEF_SIGNAL handler  (SPEC §6.1)
+ *
+ * Payload layout:
+ *   1B  name_len
+ *   NB  name
+ *   1B  data_type  (0x01=uint, 0x02=sint, 0x03=float)
+ *   1B  byte_order (0x01=little, 0x02=big)
+ *   1B  bit_length
+ *   8B  scale   (IEEE 754 double, big-endian)
+ *   8B  offset  (IEEE 754 double, big-endian)
+ *   8B  min     (IEEE 754 double, big-endian)
+ *   8B  max     (IEEE 754 double, big-endian)
+ * ---------------------------------------------------------------------- */
+
+static int handle_def_signal(int fd, const proto_frame_t *frame)
+{
+    /* Minimum: name_len(1) + name(≥1) + data_type(1) + byte_order(1) +
+     *          bit_length(1) + scale(8) + offset(8) + min(8) + max(8) = 37 */
+    if (frame->hdr.payload_len < 37u) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    const uint8_t *p         = frame->payload;
+    uint32_t       remaining = frame->hdr.payload_len;
+
+    uint8_t name_len = *p++; remaining--;
+    if (name_len == 0 || name_len > PROTO_MAX_NAME ||
+        remaining < (uint32_t)name_len) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    char name[PROTO_MAX_NAME + 1];
+    memcpy(name, p, name_len);
+    name[name_len] = '\0';
+    p += name_len; remaining -= name_len;
+
+    /* Need: data_type(1) + byte_order(1) + bit_length(1) + 4 * 8B doubles */
+    if (remaining < 35u) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    uint8_t data_type  = *p++; remaining--;
+    uint8_t byte_order = *p++; remaining--;
+    uint8_t bit_length = *p++; remaining--;
+
+    if (data_type < 0x01u || data_type > 0x03u ||
+        byte_order < 0x01u || byte_order > 0x02u ||
+        bit_length == 0) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    double scale      = read_be_double(p); p += 8; remaining -= 8;
+    double offset_val = read_be_double(p); p += 8; remaining -= 8;
+    double min_val    = read_be_double(p); p += 8; remaining -= 8;
+    double max_val    = read_be_double(p); p += 8; remaining -= 8;
+
+    /* Namespace conflict: name exists as a different type */
+    uint8_t existing_type = namespace_type(name);
+    if (existing_type != 0 && existing_type != DEF_TYPE_SIGNAL) {
+        proto_send_err(fd, ERR_DEF_CONFLICT, NULL);
+        return 0;
+    }
+
+    /* Same-type redefinition: reject if a PDU depends on this signal */
+    if (existing_type == DEF_TYPE_SIGNAL && signal_has_dependents(name)) {
+        proto_send_err(fd, ERR_DEF_IN_USE, NULL);
+        return 0;
+    }
+
+    /* Insert or overwrite */
+    signal_def_t *slot = signal_find(name);
+    if (!slot) {
+        if (g_signal_count >= MAX_SIGNALS) {
+            proto_send_err(fd, ERR_DEF_INVALID, NULL);
+            return 0;
+        }
+        slot = &g_signals[g_signal_count++];
+    }
+
+    memcpy(slot->name, name, name_len + 1);
+    slot->data_type  = data_type;
+    slot->byte_order = byte_order;
+    slot->bit_length = bit_length;
+    slot->scale      = scale;
+    slot->offset_val = offset_val;
+    slot->min_val    = min_val;
+    slot->max_val    = max_val;
+
+    return proto_send_ack(fd, MSG_DEF_ACK, NULL, 0);
+}
+
+/* -------------------------------------------------------------------------
+ * DEF_PDU handler  (SPEC §6.2)
+ *
+ * Payload layout:
+ *   1B  name_len
+ *   NB  name
+ *   1B  pdu_length  (in bytes)
+ *   1B  signal_count  (≤ 32)
+ *   for each signal:
+ *     1B  sig_name_len
+ *     NB  sig_name
+ *     1B  start_bit
+ * ---------------------------------------------------------------------- */
+
+static int handle_def_pdu(int fd, const proto_frame_t *frame)
+{
+    /* Minimum: name_len(1) + name(≥1) + pdu_length(1) + signal_count(1) = 4 */
+    if (frame->hdr.payload_len < 4u) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    const uint8_t *p         = frame->payload;
+    uint32_t       remaining = frame->hdr.payload_len;
+
+    uint8_t name_len = *p++; remaining--;
+    if (name_len == 0 || name_len > PROTO_MAX_NAME ||
+        remaining < (uint32_t)name_len) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    char name[PROTO_MAX_NAME + 1];
+    memcpy(name, p, name_len);
+    name[name_len] = '\0';
+    p += name_len; remaining -= name_len;
+
+    if (remaining < 2u) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    uint8_t pdu_length    = *p++; remaining--;
+    uint8_t signal_count  = *p++; remaining--;
+
+    if (signal_count > MAX_SIGNALS_PER_PDU) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    /* Parse signal mappings, validating references as we go */
+    pdu_signal_mapping_t mappings[MAX_SIGNALS_PER_PDU];
+
+    for (int i = 0; i < (int)signal_count; i++) {
+        if (remaining < 1u) {
+            proto_send_err(fd, ERR_DEF_INVALID, NULL);
+            return 0;
+        }
+        uint8_t sname_len = *p++; remaining--;
+
+        if (sname_len == 0 || sname_len > PROTO_MAX_NAME ||
+            remaining < (uint32_t)sname_len + 1u) {
+            proto_send_err(fd, ERR_DEF_INVALID, NULL);
+            return 0;
+        }
+
+        char sname[PROTO_MAX_NAME + 1];
+        memcpy(sname, p, sname_len);
+        sname[sname_len] = '\0';
+        p += sname_len; remaining -= sname_len;
+
+        uint8_t start_bit = *p++; remaining--;
+
+        /* Signal must already be defined */
+        if (!signal_find(sname)) {
+            proto_send_err(fd, ERR_DEF_INVALID, NULL);
+            return 0;
+        }
+
+        memcpy(mappings[i].sig_name, sname, sname_len + 1);
+        mappings[i].start_bit = start_bit;
+    }
+
+    /* Namespace conflict check */
+    uint8_t existing_type = namespace_type(name);
+    if (existing_type != 0 && existing_type != DEF_TYPE_PDU) {
+        proto_send_err(fd, ERR_DEF_CONFLICT, NULL);
+        return 0;
+    }
+
+    /* Same-type redefinition: reject if a frame depends on this PDU */
+    if (existing_type == DEF_TYPE_PDU && pdu_has_dependents(name)) {
+        proto_send_err(fd, ERR_DEF_IN_USE, NULL);
+        return 0;
+    }
+
+    /* Insert or overwrite */
+    pdu_def_t *slot = pdu_find(name);
+    if (!slot) {
+        if (g_pdu_count >= MAX_PDUS) {
+            proto_send_err(fd, ERR_DEF_INVALID, NULL);
+            return 0;
+        }
+        slot = &g_pdus[g_pdu_count++];
+    }
+
+    memcpy(slot->name, name, name_len + 1);
+    slot->length       = pdu_length;
+    slot->signal_count = signal_count;
+    memcpy(slot->signals, mappings, signal_count * sizeof(pdu_signal_mapping_t));
+
+    return proto_send_ack(fd, MSG_DEF_ACK, NULL, 0);
+}
+
+/* -------------------------------------------------------------------------
+ * DEF_FRAME handler  (SPEC §6.3)
+ *
+ * Payload layout:
+ *   1B  name_len
+ *   NB  name
+ *   4B  can_id     (big-endian)
+ *   1B  id_type    (0x01=standard, 0x02=extended)
+ *   1B  dlc
+ *   2B  tx_period  (big-endian, ms; 0=event-driven)
+ *   1B  pdu_count  (≤ 8)
+ *   for each PDU:
+ *     1B  pdu_name_len
+ *     NB  pdu_name
+ *     1B  byte_offset
+ * ---------------------------------------------------------------------- */
+
+static int handle_def_frame(int fd, const proto_frame_t *frame)
+{
+    /* Minimum: name_len(1) + name(≥1) + can_id(4) + id_type(1) +
+     *          dlc(1) + tx_period(2) + pdu_count(1) = 11 */
+    if (frame->hdr.payload_len < 11u) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    const uint8_t *p         = frame->payload;
+    uint32_t       remaining = frame->hdr.payload_len;
+
+    uint8_t name_len = *p++; remaining--;
+    if (name_len == 0 || name_len > PROTO_MAX_NAME ||
+        remaining < (uint32_t)name_len) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    char name[PROTO_MAX_NAME + 1];
+    memcpy(name, p, name_len);
+    name[name_len] = '\0';
+    p += name_len; remaining -= name_len;
+
+    /* Need: can_id(4) + id_type(1) + dlc(1) + tx_period(2) + pdu_count(1) */
+    if (remaining < 9u) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    uint32_t can_id    = ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16)
+                       | ((uint32_t)p[2] <<  8) |  (uint32_t)p[3];
+    p += 4; remaining -= 4;
+
+    uint8_t  id_type   = *p++; remaining--;
+    uint8_t  dlc       = *p++; remaining--;
+    uint16_t tx_period = (uint16_t)(((uint16_t)p[0] << 8) | p[1]);
+    p += 2; remaining -= 2;
+    uint8_t  pdu_count = *p++; remaining--;
+
+    if ((id_type != 0x01u && id_type != 0x02u) || pdu_count > MAX_PDUS_PER_FRAME) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    /* Parse PDU mappings, validating references as we go */
+    frame_pdu_mapping_t mappings[MAX_PDUS_PER_FRAME];
+
+    for (int i = 0; i < (int)pdu_count; i++) {
+        if (remaining < 1u) {
+            proto_send_err(fd, ERR_DEF_INVALID, NULL);
+            return 0;
+        }
+        uint8_t pname_len = *p++; remaining--;
+
+        if (pname_len == 0 || pname_len > PROTO_MAX_NAME ||
+            remaining < (uint32_t)pname_len + 1u) {
+            proto_send_err(fd, ERR_DEF_INVALID, NULL);
+            return 0;
+        }
+
+        char pname[PROTO_MAX_NAME + 1];
+        memcpy(pname, p, pname_len);
+        pname[pname_len] = '\0';
+        p += pname_len; remaining -= pname_len;
+
+        uint8_t byte_offset = *p++; remaining--;
+
+        /* PDU must already be defined */
+        if (!pdu_find(pname)) {
+            proto_send_err(fd, ERR_DEF_INVALID, NULL);
+            return 0;
+        }
+
+        memcpy(mappings[i].pdu_name, pname, pname_len + 1);
+        mappings[i].byte_offset = byte_offset;
+    }
+
+    /* Namespace conflict check */
+    uint8_t existing_type = namespace_type(name);
+    if (existing_type != 0 && existing_type != DEF_TYPE_FRAME) {
+        proto_send_err(fd, ERR_DEF_CONFLICT, NULL);
+        return 0;
+    }
+
+    /* Insert or overwrite (frames have no dependents, so no DEF_IN_USE check) */
+    frame_def_t *slot = frame_find(name);
+    if (!slot) {
+        if (g_frame_count >= MAX_FRAMES) {
+            proto_send_err(fd, ERR_DEF_INVALID, NULL);
+            return 0;
+        }
+        slot = &g_frames[g_frame_count++];
+    }
+
+    memcpy(slot->name, name, name_len + 1);
+    slot->can_id    = can_id;
+    slot->id_type   = id_type;
+    slot->dlc       = dlc;
+    slot->tx_period = tx_period;
+    slot->pdu_count = pdu_count;
+    memcpy(slot->pdus, mappings, pdu_count * sizeof(frame_pdu_mapping_t));
+
+    return proto_send_ack(fd, MSG_DEF_ACK, NULL, 0);
+}
+
+/* -------------------------------------------------------------------------
+ * DEF_DELETE handler  (SPEC §6.4)
+ *
+ * Payload layout:
+ *   1B  name_len
+ *   NB  name
+ *   1B  def_type  (0x01=signal, 0x02=PDU, 0x03=frame)
+ * ---------------------------------------------------------------------- */
+
+static int handle_def_delete(int fd, const proto_frame_t *frame)
+{
+    /* Minimum: name_len(1) + name(≥1) + def_type(1) = 3 */
+    if (frame->hdr.payload_len < 3u) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    const uint8_t *p         = frame->payload;
+    uint32_t       remaining = frame->hdr.payload_len;
+
+    uint8_t name_len = *p++; remaining--;
+    if (name_len == 0 || name_len > PROTO_MAX_NAME ||
+        remaining < (uint32_t)name_len + 1u) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    char name[PROTO_MAX_NAME + 1];
+    memcpy(name, p, name_len);
+    name[name_len] = '\0';
+    p += name_len; remaining -= name_len;
+
+    uint8_t def_type = *p++; remaining--;
+
+    if (def_type < DEF_TYPE_SIGNAL || def_type > DEF_TYPE_FRAME) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    /* Verify the name exists and matches the declared type */
+    uint8_t actual_type = namespace_type(name);
+    if (actual_type == 0 || actual_type != def_type) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    if (def_type == DEF_TYPE_SIGNAL) {
+        if (signal_has_dependents(name)) {
+            proto_send_err(fd, ERR_DEF_IN_USE, NULL);
+            return 0;
+        }
+        /* Remove by swapping with the last entry */
+        signal_def_t *entry = signal_find(name);
+        int idx = (int)(entry - g_signals);
+        if (idx < g_signal_count - 1)
+            g_signals[idx] = g_signals[g_signal_count - 1];
+        g_signal_count--;
+
+    } else if (def_type == DEF_TYPE_PDU) {
+        if (pdu_has_dependents(name)) {
+            proto_send_err(fd, ERR_DEF_IN_USE, NULL);
+            return 0;
+        }
+        pdu_def_t *entry = pdu_find(name);
+        int idx = (int)(entry - g_pdus);
+        if (idx < g_pdu_count - 1)
+            g_pdus[idx] = g_pdus[g_pdu_count - 1];
+        g_pdu_count--;
+
+    } else { /* DEF_TYPE_FRAME */
+        frame_def_t *entry = frame_find(name);
+        int idx = (int)(entry - g_frames);
+        if (idx < g_frame_count - 1)
+            g_frames[idx] = g_frames[g_frame_count - 1];
+        g_frame_count--;
+    }
+
+    return proto_send_ack(fd, MSG_DEF_ACK, NULL, 0);
+}
+
+/* -------------------------------------------------------------------------
+ * Module lifecycle
+ * ---------------------------------------------------------------------- */
+
+void def_init(void)
+{
+    g_signal_count = 0;
+    g_pdu_count    = 0;
+    g_frame_count  = 0;
+}
+
+void def_destroy(void)
+{
+    g_signal_count = 0;
+    g_pdu_count    = 0;
+    g_frame_count  = 0;
+}
+
+void def_register_handlers(void)
+{
+    proto_register_handler(MSG_DEF_SIGNAL, handle_def_signal);
+    proto_register_handler(MSG_DEF_PDU,    handle_def_pdu);
+    proto_register_handler(MSG_DEF_FRAME,  handle_def_frame);
+    proto_register_handler(MSG_DEF_DELETE, handle_def_delete);
+}

--- a/server/def.h
+++ b/server/def.h
@@ -1,0 +1,16 @@
+#ifndef ASH_SERVER_DEF_H
+#define ASH_SERVER_DEF_H
+
+/* -------------------------------------------------------------------------
+ * Signal/PDU/Frame definition store  (SPEC §6, §8.5)
+ *
+ * Global, session-agnostic in-memory namespace.  Definitions survive client
+ * disconnects.  All three definition types share a single name namespace:
+ * a name may not be used simultaneously for different types.
+ * ---------------------------------------------------------------------- */
+
+void def_init(void);
+void def_destroy(void);
+void def_register_handlers(void);
+
+#endif /* ASH_SERVER_DEF_H */

--- a/server/server.c
+++ b/server/server.c
@@ -2,6 +2,7 @@
 #include "proto.h"
 #include "session.h"
 #include "iface.h"
+#include "def.h"
 
 #include <sys/epoll.h>
 #include <sys/signalfd.h>
@@ -191,6 +192,10 @@ int server_init(server_t *s, uint16_t port, const char *storage_dir)
     if (iface_init(s) < 0)
         return -1;
 
+    /* --- Definition store --- */
+    def_init();
+    def_register_handlers();
+
     printf("ash-server listening on port %u\n", (unsigned)port);
     return 0;
 }
@@ -353,6 +358,7 @@ void server_destroy(server_t *s)
         s->sessions[i].fd = -1;
     }
 
+    def_destroy();
     iface_destroy();
 
     if (s->listen_fd >= 0) {

--- a/tools/test_client.py
+++ b/tools/test_client.py
@@ -10,6 +10,7 @@ Default host/port: 127.0.0.1:4000
 Tests 1-7 run automatically.
 Tests 10-16 (CAN interface management) run automatically; the server must have
 CAP_NET_ADMIN (root) to create/destroy vcan interfaces.
+Tests 18-28 (definition store) run automatically.
 Test 8 (graceful server shutdown) requires manually stopping the server and
 must be requested with --test 8.
 Test 9 (keep-alive timeout) waits 30+ seconds and must be requested with --test 9.
@@ -67,6 +68,21 @@ ERR_IFACE_ATTACH_FAILED     = 0x0012
 IFACE_STATE_AVAILABLE       = 0x01
 IFACE_STATE_ATTACHED_THIS   = 0x02
 IFACE_STATE_ATTACHED_OTHER  = 0x03
+
+# Definition management (SPEC §6)
+MSG_DEF_SIGNAL  = 0x0020
+MSG_DEF_PDU     = 0x0021
+MSG_DEF_FRAME   = 0x0022
+MSG_DEF_DELETE  = 0x0023
+MSG_DEF_ACK     = 0x8020
+
+ERR_DEF_INVALID   = 0x0020
+ERR_DEF_CONFLICT  = 0x0021
+ERR_DEF_IN_USE    = 0x0022
+
+DEF_TYPE_SIGNAL = 0x01
+DEF_TYPE_PDU    = 0x02
+DEF_TYPE_FRAME  = 0x03
 
 KEEPALIVE_TIMEOUT_SEC    = 30
 
@@ -146,6 +162,11 @@ MSG_NAMES = {
     0x8011: 'IFACE_ATTACH_ACK',
     0x8012: 'IFACE_DETACH_ACK',
     0x8013: 'IFACE_VCAN_ACK',
+    0x0020: 'DEF_SIGNAL',
+    0x0021: 'DEF_PDU',
+    0x0022: 'DEF_FRAME',
+    0x0023: 'DEF_DELETE',
+    0x8020: 'DEF_ACK',
     0xFFFF: 'MSG_ERR',
 }
 
@@ -159,6 +180,9 @@ ERR_NAMES = {
     0x0010: 'ERR_IFACE_NOT_FOUND',
     0x0011: 'ERR_IFACE_ALREADY_ATTACHED',
     0x0012: 'ERR_IFACE_ATTACH_FAILED',
+    0x0020: 'ERR_DEF_INVALID',
+    0x0021: 'ERR_DEF_CONFLICT',
+    0x0022: 'ERR_DEF_IN_USE',
 }
 
 def fmt_type(t):
@@ -822,6 +846,345 @@ def test_notify_iface_down(host, port):
         print('  [skipped]')
 
 
+# ── Definition management helpers ────────────────────────────────────────────
+
+def make_def_signal(name, data_type=0x01, byte_order=0x01, bit_length=8,
+                    scale=1.0, offset=0.0, min_val=0.0, max_val=255.0):
+    """Build a DEF_SIGNAL frame (SPEC §6.1).
+
+    data_type:  0x01=uint, 0x02=sint, 0x03=float
+    byte_order: 0x01=little-endian, 0x02=big-endian
+    """
+    n = name.encode()
+    payload = bytes([len(n)]) + n
+    payload += bytes([data_type, byte_order, bit_length])
+    payload += struct.pack('>dddd', scale, offset, min_val, max_val)
+    return make_frame(PROTO_VERSION, MSG_DEF_SIGNAL, payload)
+
+
+def make_def_pdu(name, pdu_length, signal_mappings):
+    """Build a DEF_PDU frame (SPEC §6.2).
+
+    signal_mappings: list of (signal_name, start_bit) tuples
+    """
+    n = name.encode()
+    payload = bytes([len(n)]) + n + bytes([pdu_length, len(signal_mappings)])
+    for sig_name, start_bit in signal_mappings:
+        sn = sig_name.encode()
+        payload += bytes([len(sn)]) + sn + bytes([start_bit])
+    return make_frame(PROTO_VERSION, MSG_DEF_PDU, payload)
+
+
+def make_def_frame(name, can_id, id_type, dlc, tx_period, pdu_mappings):
+    """Build a DEF_FRAME frame (SPEC §6.3).
+
+    id_type:     0x01=standard (11-bit), 0x02=extended (29-bit)
+    tx_period:   ms; 0 = event-driven
+    pdu_mappings: list of (pdu_name, byte_offset) tuples
+    """
+    n = name.encode()
+    payload = bytes([len(n)]) + n
+    payload += struct.pack('>I', can_id)
+    payload += bytes([id_type, dlc])
+    payload += struct.pack('>H', tx_period)
+    payload += bytes([len(pdu_mappings)])
+    for pdu_name, byte_offset in pdu_mappings:
+        pn = pdu_name.encode()
+        payload += bytes([len(pn)]) + pn + bytes([byte_offset])
+    return make_frame(PROTO_VERSION, MSG_DEF_FRAME, payload)
+
+
+def make_def_delete(name, def_type):
+    """Build a DEF_DELETE frame (SPEC §6.4).
+
+    def_type: DEF_TYPE_SIGNAL, DEF_TYPE_PDU, or DEF_TYPE_FRAME
+    """
+    n = name.encode()
+    payload = bytes([len(n)]) + n + bytes([def_type])
+    return make_frame(PROTO_VERSION, MSG_DEF_DELETE, payload)
+
+
+def def_cleanup(s, *name_type_pairs):
+    """Best-effort DEF_DELETE for each (name, def_type) pair (reverse order)."""
+    for name, def_type in reversed(name_type_pairs):
+        s.sendall(make_def_delete(name, def_type))
+        recv_frame(s)
+
+
+# ── Definition store tests (SPEC §6) ─────────────────────────────────────────
+
+def test_def_signal(host, port):
+    """Test 18 — DEF_SIGNAL: define a signal → DEF_ACK."""
+    print('\n[18] DEF_SIGNAL — expect DEF_ACK')
+    with open_session(host, port, 'def-sig-test')[0] as s:
+        s.sendall(make_def_signal('t18_sig'))
+        frame = recv_frame(s)
+        print_response(frame)
+        if not check(frame is not None, 'received a response'):
+            return
+        _, msg_type, _ = frame
+        check(msg_type == MSG_DEF_ACK,
+              f'response is DEF_ACK (got {fmt_type(msg_type)})')
+        def_cleanup(s, ('t18_sig', DEF_TYPE_SIGNAL))
+
+
+def test_def_pdu(host, port):
+    """Test 19 — DEF_PDU: define signal then PDU referencing it → DEF_ACK."""
+    print('\n[19] DEF_PDU — define signal then PDU referencing it, expect DEF_ACK')
+    with open_session(host, port, 'def-pdu-test')[0] as s:
+        # Prerequisite: define the signal
+        s.sendall(make_def_signal('t19_sig'))
+        if recv_frame(s) is None:
+            check(False, 'DEF_SIGNAL prerequisite failed')
+            return
+
+        s.sendall(make_def_pdu('t19_pdu', 8, [('t19_sig', 0)]))
+        frame = recv_frame(s)
+        print_response(frame)
+        if not check(frame is not None, 'received a response'):
+            def_cleanup(s, ('t19_sig', DEF_TYPE_SIGNAL))
+            return
+        _, msg_type, _ = frame
+        check(msg_type == MSG_DEF_ACK,
+              f'response is DEF_ACK (got {fmt_type(msg_type)})')
+        def_cleanup(s, ('t19_sig', DEF_TYPE_SIGNAL), ('t19_pdu', DEF_TYPE_PDU))
+
+
+def test_def_frame(host, port):
+    """Test 20 — DEF_FRAME: full define chain signal → PDU → frame → DEF_ACK."""
+    print('\n[20] DEF_FRAME — full define chain, expect DEF_ACK for each')
+    with open_session(host, port, 'def-frame-test')[0] as s:
+        s.sendall(make_def_signal('t20_sig'))
+        if recv_frame(s) is None:
+            check(False, 'DEF_SIGNAL prerequisite failed')
+            return
+
+        s.sendall(make_def_pdu('t20_pdu', 8, [('t20_sig', 0)]))
+        if recv_frame(s) is None:
+            check(False, 'DEF_PDU prerequisite failed')
+            def_cleanup(s, ('t20_sig', DEF_TYPE_SIGNAL))
+            return
+
+        s.sendall(make_def_frame('t20_frame', 0x123, 0x01, 8, 0,
+                                 [('t20_pdu', 0)]))
+        frame = recv_frame(s)
+        print_response(frame)
+        if not check(frame is not None, 'received a response'):
+            def_cleanup(s, ('t20_sig', DEF_TYPE_SIGNAL), ('t20_pdu', DEF_TYPE_PDU))
+            return
+        _, msg_type, _ = frame
+        check(msg_type == MSG_DEF_ACK,
+              f'response is DEF_ACK (got {fmt_type(msg_type)})')
+        def_cleanup(s,
+                    ('t20_sig', DEF_TYPE_SIGNAL),
+                    ('t20_pdu', DEF_TYPE_PDU),
+                    ('t20_frame', DEF_TYPE_FRAME))
+
+
+def test_def_pdu_unknown_signal(host, port):
+    """Test 21 — DEF_PDU with an undefined signal reference → ERR_DEF_INVALID."""
+    print('\n[21] DEF_PDU with unknown signal — expect ERR_DEF_INVALID')
+    with open_session(host, port, 'def-pdu-badsig')[0] as s:
+        s.sendall(make_def_pdu('t21_pdu', 8, [('no_such_signal', 0)]))
+        frame = recv_frame(s)
+        print_response(frame)
+        if not check(frame is not None, 'received a response'):
+            return
+        _, msg_type, payload = frame
+        check(msg_type == MSG_ERR,
+              f'response is MSG_ERR (got {fmt_type(msg_type)})')
+        code, _ = decode_err(payload)
+        check(code == ERR_DEF_INVALID,
+              f'err_code is ERR_DEF_INVALID (got {fmt_err(code)})')
+
+
+def test_def_frame_unknown_pdu(host, port):
+    """Test 22 — DEF_FRAME with an undefined PDU reference → ERR_DEF_INVALID."""
+    print('\n[22] DEF_FRAME with unknown PDU — expect ERR_DEF_INVALID')
+    with open_session(host, port, 'def-frame-badpdu')[0] as s:
+        s.sendall(make_def_frame('t22_frame', 0x456, 0x01, 8, 0,
+                                 [('no_such_pdu', 0)]))
+        frame = recv_frame(s)
+        print_response(frame)
+        if not check(frame is not None, 'received a response'):
+            return
+        _, msg_type, payload = frame
+        check(msg_type == MSG_ERR,
+              f'response is MSG_ERR (got {fmt_type(msg_type)})')
+        code, _ = decode_err(payload)
+        check(code == ERR_DEF_INVALID,
+              f'err_code is ERR_DEF_INVALID (got {fmt_err(code)})')
+
+
+def test_def_type_conflict(host, port):
+    """Test 23 — Reusing a signal name as a PDU name → ERR_DEF_CONFLICT."""
+    print('\n[23] Type conflict: define signal, reuse name as PDU — expect ERR_DEF_CONFLICT')
+    with open_session(host, port, 'def-conflict-test')[0] as s:
+        s.sendall(make_def_signal('t23_name'))
+        if recv_frame(s) is None:
+            check(False, 'DEF_SIGNAL prerequisite failed')
+            return
+
+        # Attempt to define a PDU with the same name
+        s.sendall(make_def_pdu('t23_name', 8, []))
+        frame = recv_frame(s)
+        print_response(frame)
+        if not check(frame is not None, 'received a response'):
+            def_cleanup(s, ('t23_name', DEF_TYPE_SIGNAL))
+            return
+        _, msg_type, payload = frame
+        check(msg_type == MSG_ERR,
+              f'response is MSG_ERR (got {fmt_type(msg_type)})')
+        code, _ = decode_err(payload)
+        check(code == ERR_DEF_CONFLICT,
+              f'err_code is ERR_DEF_CONFLICT (got {fmt_err(code)})')
+        def_cleanup(s, ('t23_name', DEF_TYPE_SIGNAL))
+
+
+def test_def_delete_signal_in_use(host, port):
+    """Test 24 — Delete a signal referenced by a PDU → ERR_DEF_IN_USE."""
+    print('\n[24] DEF_DELETE signal in use by PDU — expect ERR_DEF_IN_USE')
+    with open_session(host, port, 'def-del-sig-inuse')[0] as s:
+        s.sendall(make_def_signal('t24_sig'))
+        if recv_frame(s) is None:
+            check(False, 'DEF_SIGNAL prerequisite failed')
+            return
+        s.sendall(make_def_pdu('t24_pdu', 8, [('t24_sig', 0)]))
+        if recv_frame(s) is None:
+            check(False, 'DEF_PDU prerequisite failed')
+            def_cleanup(s, ('t24_sig', DEF_TYPE_SIGNAL))
+            return
+
+        s.sendall(make_def_delete('t24_sig', DEF_TYPE_SIGNAL))
+        frame = recv_frame(s)
+        print_response(frame)
+        if not check(frame is not None, 'received a response'):
+            def_cleanup(s, ('t24_sig', DEF_TYPE_SIGNAL), ('t24_pdu', DEF_TYPE_PDU))
+            return
+        _, msg_type, payload = frame
+        check(msg_type == MSG_ERR,
+              f'response is MSG_ERR (got {fmt_type(msg_type)})')
+        code, _ = decode_err(payload)
+        check(code == ERR_DEF_IN_USE,
+              f'err_code is ERR_DEF_IN_USE (got {fmt_err(code)})')
+        def_cleanup(s, ('t24_sig', DEF_TYPE_SIGNAL), ('t24_pdu', DEF_TYPE_PDU))
+
+
+def test_def_delete_pdu_in_use(host, port):
+    """Test 25 — Delete a PDU referenced by a frame → ERR_DEF_IN_USE."""
+    print('\n[25] DEF_DELETE PDU in use by frame — expect ERR_DEF_IN_USE')
+    with open_session(host, port, 'def-del-pdu-inuse')[0] as s:
+        s.sendall(make_def_signal('t25_sig'))
+        if recv_frame(s) is None:
+            check(False, 'DEF_SIGNAL prerequisite failed')
+            return
+        s.sendall(make_def_pdu('t25_pdu', 8, [('t25_sig', 0)]))
+        if recv_frame(s) is None:
+            check(False, 'DEF_PDU prerequisite failed')
+            def_cleanup(s, ('t25_sig', DEF_TYPE_SIGNAL))
+            return
+        s.sendall(make_def_frame('t25_frame', 0x789, 0x01, 8, 0,
+                                 [('t25_pdu', 0)]))
+        if recv_frame(s) is None:
+            check(False, 'DEF_FRAME prerequisite failed')
+            def_cleanup(s, ('t25_sig', DEF_TYPE_SIGNAL), ('t25_pdu', DEF_TYPE_PDU))
+            return
+
+        s.sendall(make_def_delete('t25_pdu', DEF_TYPE_PDU))
+        frame = recv_frame(s)
+        print_response(frame)
+        if not check(frame is not None, 'received a response'):
+            def_cleanup(s, ('t25_sig', DEF_TYPE_SIGNAL), ('t25_pdu', DEF_TYPE_PDU),
+                        ('t25_frame', DEF_TYPE_FRAME))
+            return
+        _, msg_type, payload = frame
+        check(msg_type == MSG_ERR,
+              f'response is MSG_ERR (got {fmt_type(msg_type)})')
+        code, _ = decode_err(payload)
+        check(code == ERR_DEF_IN_USE,
+              f'err_code is ERR_DEF_IN_USE (got {fmt_err(code)})')
+        def_cleanup(s, ('t25_sig', DEF_TYPE_SIGNAL), ('t25_pdu', DEF_TYPE_PDU),
+                    ('t25_frame', DEF_TYPE_FRAME))
+
+
+def test_def_pdu_signal_count_limit(host, port):
+    """Test 26 — DEF_PDU with signal_count > 32 → ERR_DEF_INVALID."""
+    print('\n[26] DEF_PDU signal_count=33 (> 32 limit) — expect ERR_DEF_INVALID')
+    with open_session(host, port, 'def-pdu-siglimit')[0] as s:
+        # Build a PDU payload with signal_count=33 but no actual mappings.
+        # The server validates the count before parsing mappings.
+        n = b't26_pdu'
+        payload = bytes([len(n)]) + n + bytes([8, 33])  # pdu_length=8, signal_count=33
+        s.sendall(make_frame(PROTO_VERSION, MSG_DEF_PDU, payload))
+        frame = recv_frame(s)
+        print_response(frame)
+        if not check(frame is not None, 'received a response'):
+            return
+        _, msg_type, payload_resp = frame
+        check(msg_type == MSG_ERR,
+              f'response is MSG_ERR (got {fmt_type(msg_type)})')
+        code, _ = decode_err(payload_resp)
+        check(code == ERR_DEF_INVALID,
+              f'err_code is ERR_DEF_INVALID (got {fmt_err(code)})')
+
+
+def test_def_frame_pdu_count_limit(host, port):
+    """Test 27 — DEF_FRAME with pdu_count > 8 → ERR_DEF_INVALID."""
+    print('\n[27] DEF_FRAME pdu_count=9 (> 8 limit) — expect ERR_DEF_INVALID')
+    with open_session(host, port, 'def-frame-pdulimit')[0] as s:
+        # Build a FRAME payload with pdu_count=9 but no actual mappings.
+        n = b't27_frame'
+        payload  = bytes([len(n)]) + n
+        payload += struct.pack('>I', 0x100)   # can_id
+        payload += bytes([0x01, 8])            # id_type=standard, dlc=8
+        payload += struct.pack('>H', 0)        # tx_period=0
+        payload += bytes([9])                  # pdu_count=9 (over limit)
+        s.sendall(make_frame(PROTO_VERSION, MSG_DEF_FRAME, payload))
+        frame = recv_frame(s)
+        print_response(frame)
+        if not check(frame is not None, 'received a response'):
+            return
+        _, msg_type, payload_resp = frame
+        check(msg_type == MSG_ERR,
+              f'response is MSG_ERR (got {fmt_type(msg_type)})')
+        code, _ = decode_err(payload_resp)
+        check(code == ERR_DEF_INVALID,
+              f'err_code is ERR_DEF_INVALID (got {fmt_err(code)})')
+
+
+def test_def_persistence(host, port):
+    """Test 28 — Definitions persist after session disconnect."""
+    print('\n[28] Definition persistence — signal defined in session 1 visible to session 2')
+    # Session 1: define signal
+    s1, _ = open_session(host, port, 'def-persist-s1')
+    if s1 is None:
+        check(False, 'could not establish session 1 (prerequisite failed)')
+        return
+
+    try:
+        s1.sendall(make_def_signal('t28_sig'))
+        if recv_frame(s1) is None:
+            check(False, 'DEF_SIGNAL in session 1 failed')
+            return
+        s1.sendall(make_frame(PROTO_VERSION, MSG_SESSION_CLOSE))
+        recv_frame(s1)
+    finally:
+        s1.close()
+
+    # Session 2: define a PDU referencing the signal from session 1 — must succeed
+    with open_session(host, port, 'def-persist-s2')[0] as s2:
+        s2.sendall(make_def_pdu('t28_pdu', 8, [('t28_sig', 0)]))
+        frame = recv_frame(s2)
+        print_response(frame)
+        if not check(frame is not None, 'received a response in session 2'):
+            def_cleanup(s2, ('t28_sig', DEF_TYPE_SIGNAL))
+            return
+        _, msg_type, _ = frame
+        check(msg_type == MSG_DEF_ACK,
+              f'DEF_PDU referencing persisted signal succeeds (got {fmt_type(msg_type)})')
+        def_cleanup(s2, ('t28_sig', DEF_TYPE_SIGNAL), ('t28_pdu', DEF_TYPE_PDU))
+
+
 # ── Entry point ───────────────────────────────────────────────────────────────
 
 TESTS = [
@@ -842,9 +1205,20 @@ TESTS = [
     test_session_close_releases_iface,  # 15
     test_iface_vcan_destroy,            # 16
     test_notify_iface_down,             # 17 — interactive
+    test_def_signal,                    # 18
+    test_def_pdu,                       # 19
+    test_def_frame,                     # 20
+    test_def_pdu_unknown_signal,        # 21
+    test_def_frame_unknown_pdu,         # 22
+    test_def_type_conflict,             # 23
+    test_def_delete_signal_in_use,      # 24
+    test_def_delete_pdu_in_use,         # 25
+    test_def_pdu_signal_count_limit,    # 26
+    test_def_frame_pdu_count_limit,     # 27
+    test_def_persistence,               # 28
 ]
 
-AUTO_TESTS = TESTS[:7] + TESTS[9:16]   # 1-7 and 10-16 run unattended
+AUTO_TESTS = TESTS[:7] + TESTS[9:16] + TESTS[17:]  # 1-7, 10-16, and 18-28 run unattended
 
 
 def main():
@@ -874,6 +1248,7 @@ def main():
         print('\n[8]  Graceful shutdown    — run with --test 8')
         print('[9]  Keep-alive timeout  — run with --test 9 (takes 35 s)')
         print('[17] NOTIFY_IFACE_DOWN   — run with --test 17 (requires manual ip link delete)')
+        print('     (Tests 18-28 run automatically above)')
 
     print()
 


### PR DESCRIPTION
## Summary

- Add `server/def.c` and `server/def.h` implementing all four definition-plane handlers: `DEF_SIGNAL`, `DEF_PDU`, `DEF_FRAME`, `DEF_DELETE`
- Global in-memory stores: `g_signals[512]`, `g_pdus[256]`, `g_frames[128]`; definitions survive client disconnects
- Shared single-name namespace across all three types; `ERR_DEF_CONFLICT` returned on type mismatch

## Details

- **DEF_SIGNAL**: parses name, data_type, byte_order, bit_length, and four IEEE 754 big-endian doubles (scale, offset, min, max); validates field ranges
- **DEF_PDU**: enforces `signal_count ≤ 32`; validates all referenced signals already exist; rejects same-name redefinition when a frame depends on the PDU (`ERR_DEF_IN_USE`)
- **DEF_FRAME**: enforces `pdu_count ≤ 8`; validates all referenced PDUs already exist
- **DEF_DELETE**: checks dependency chain before removal (`ERR_DEF_IN_USE`); O(1) swap-with-last removal
- `def_init` / `def_register_handlers` called from `server_init`; `def_destroy` called from `server_destroy`

## Test plan

- [x] `DEF_SIGNAL` → `DEF_PDU` → `DEF_FRAME` define chain succeeds and returns `DEF_ACK`
- [x] `DEF_PDU` with unknown signal name returns `ERR_DEF_INVALID`
- [x] `DEF_FRAME` with unknown PDU name returns `ERR_DEF_INVALID`
- [x] Reusing a signal name as a PDU name returns `ERR_DEF_CONFLICT`
- [x] Deleting a signal referenced by a PDU returns `ERR_DEF_IN_USE`
- [x] Deleting a PDU referenced by a frame returns `ERR_DEF_IN_USE`
- [x] Definitions persist after client disconnect (re-connect can see same names)
- [x] `signal_count > 32` returns `ERR_DEF_INVALID`
- [x] `pdu_count > 8` returns `ERR_DEF_INVALID`

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)