### PR TITLE
#9: implement Signal Ownership & ACL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ add_compile_options($<$<CONFIG:Debug>:-Wall>
 include_directories(include)
 
 # Server
-add_executable(ash-server server/main.c server/server.c server/proto.c server/session.c server/iface.c server/def.c)
+add_executable(ash-server server/main.c server/server.c server/proto.c server/session.c server/iface.c server/def.c server/own.c)
 target_compile_definitions(ash-server PRIVATE _GNU_SOURCE)
 
 # Client library

--- a/server/def.c
+++ b/server/def.c
@@ -580,6 +580,11 @@ static int handle_def_delete(int fd, const proto_frame_t *frame)
  * Module lifecycle
  * ---------------------------------------------------------------------- */
 
+int def_signal_exists(const char *name)
+{
+    return signal_find(name) != NULL;
+}
+
 void def_init(void)
 {
     g_signal_count = 0;

--- a/server/def.h
+++ b/server/def.h
@@ -13,4 +13,7 @@ void def_init(void);
 void def_destroy(void);
 void def_register_handlers(void);
 
+/* Returns 1 if a signal with the given name is defined, 0 otherwise. */
+int def_signal_exists(const char *name);
+
 #endif /* ASH_SERVER_DEF_H */

--- a/server/own.c
+++ b/server/own.c
@@ -1,0 +1,391 @@
+#include "own.h"
+#include "proto.h"
+#include "def.h"
+
+#include "ash/proto.h"
+
+#include <stdint.h>
+#include <string.h>
+#include <stdio.h>
+
+/* -------------------------------------------------------------------------
+ * Store limit
+ * ---------------------------------------------------------------------- */
+
+#define MAX_OWN_ENTRIES  512   /* one per signal maximum */
+
+/* -------------------------------------------------------------------------
+ * Per-signal ownership record
+ * ---------------------------------------------------------------------- */
+
+typedef struct {
+    char     sig_name[PROTO_MAX_NAME + 1];
+    uint32_t session_id;    /* 0 = unowned */
+    int      client_fd;     /* fd of owning session (for NOTIFY_OWN_REVOKED) */
+    uint8_t  locked;        /* 1 = locked, 0 = unlocked */
+    uint8_t  on_disconnect; /* 0x01=stop 0x02=last 0x03=default */
+} own_entry_t;
+
+/* -------------------------------------------------------------------------
+ * Module state
+ * ---------------------------------------------------------------------- */
+
+static own_entry_t g_own[MAX_OWN_ENTRIES];
+static int         g_own_count;
+static server_t   *g_server;
+
+/* -------------------------------------------------------------------------
+ * Lookup helpers
+ * ---------------------------------------------------------------------- */
+
+static own_entry_t *own_find(const char *sig_name)
+{
+    for (int i = 0; i < g_own_count; i++) {
+        if (strcmp(g_own[i].sig_name, sig_name) == 0)
+            return &g_own[i];
+    }
+    return NULL;
+}
+
+/* Find the fd of a session by its session_id. Returns -1 if not found. */
+static int find_session_fd(uint32_t session_id)
+{
+    for (int i = 0; i < MAX_SESSIONS; i++) {
+        if (g_server->sessions[i].fd >= 0 &&
+            g_server->sessions[i].session_id == session_id)
+            return g_server->sessions[i].fd;
+    }
+    return -1;
+}
+
+/* -------------------------------------------------------------------------
+ * Response helpers
+ * ---------------------------------------------------------------------- */
+
+static int send_own_ack(int fd, const char *name)
+{
+    size_t  nlen = strlen(name);
+    uint8_t buf[PROTO_MAX_NAME + 1];
+    buf[0] = (uint8_t)nlen;
+    memcpy(buf + 1, name, nlen);
+    return proto_send_ack(fd, MSG_OWN_ACK, buf, (uint32_t)(nlen + 1));
+}
+
+static void send_own_revoked(int fd, const char *name)
+{
+    size_t  nlen = strlen(name);
+    uint8_t buf[PROTO_MAX_NAME + 1];
+    buf[0] = (uint8_t)nlen;
+    memcpy(buf + 1, name, nlen);
+    proto_send_ack(fd, MSG_NOTIFY_OWN_REVOKED, buf, (uint32_t)(nlen + 1));
+}
+
+/* -------------------------------------------------------------------------
+ * Parse helpers: all OWN messages share name_len + name prefix
+ * ---------------------------------------------------------------------- */
+
+/*
+ * Parse a name from the frame payload.  Fills `name_out` (NUL-terminated)
+ * and advances `*pp` / `*remaining`.
+ * Returns 0 on success, -1 if the payload is malformed.
+ */
+static int parse_name(const uint8_t **pp, uint32_t *remaining,
+                      char name_out[PROTO_MAX_NAME + 1])
+{
+    if (*remaining < 1u)
+        return -1;
+
+    uint8_t nlen = **pp; (*pp)++; (*remaining)--;
+
+    if (nlen == 0 || nlen > PROTO_MAX_NAME || *remaining < (uint32_t)nlen)
+        return -1;
+
+    memcpy(name_out, *pp, nlen);
+    name_out[nlen] = '\0';
+    *pp        += nlen;
+    *remaining -= nlen;
+    return 0;
+}
+
+/* -------------------------------------------------------------------------
+ * OWN_ACQUIRE handler  (SPEC §8.1)
+ *
+ * Payload:
+ *   1B  name_len
+ *   NB  name
+ *   1B  on_disconnect (0x01=stop, 0x02=last, 0x03=default)
+ * ---------------------------------------------------------------------- */
+
+static int handle_own_acquire(int fd, const proto_frame_t *frame)
+{
+    /* Minimum: name_len(1) + name(≥1) + on_disconnect(1) = 3 */
+    if (frame->hdr.payload_len < 3u) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    const uint8_t *p         = frame->payload;
+    uint32_t       remaining = frame->hdr.payload_len;
+
+    char name[PROTO_MAX_NAME + 1];
+    if (parse_name(&p, &remaining, name) < 0) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    if (remaining < 1u) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+    uint8_t on_disc = *p++; remaining--;
+
+    if (on_disc < 0x01u || on_disc > 0x03u) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    /* Signal must be defined */
+    if (!def_signal_exists(name)) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    /* Find or allocate ownership record */
+    own_entry_t *e = own_find(name);
+
+    if (e && e->session_id != 0) {
+        /* Determine requesting session */
+        uint32_t req_session = 0;
+        for (int i = 0; i < MAX_SESSIONS; i++) {
+            if (g_server->sessions[i].fd == fd) {
+                req_session = g_server->sessions[i].session_id;
+                break;
+            }
+        }
+
+        if (e->session_id == req_session) {
+            /* Re-acquire own signal: update on_disconnect, ACK */
+            e->on_disconnect = on_disc;
+            return send_own_ack(fd, name);
+        }
+
+        /* Owned by another session */
+        if (e->locked) {
+            proto_send_err(fd, ERR_OWN_NOT_AVAILABLE, NULL);
+            return 0;
+        }
+
+        /* Transfer: notify previous owner, reassign */
+        int prev_fd = find_session_fd(e->session_id);
+        if (prev_fd >= 0)
+            send_own_revoked(prev_fd, name);
+
+        e->session_id    = req_session;
+        e->client_fd     = fd;
+        e->locked        = 0;
+        e->on_disconnect = on_disc;
+        return send_own_ack(fd, name);
+    }
+
+    /* Not yet owned (or entry exists with session_id == 0) */
+    if (!e) {
+        if (g_own_count >= MAX_OWN_ENTRIES) {
+            proto_send_err(fd, ERR_OWN_NOT_AVAILABLE, NULL);
+            return 0;
+        }
+        e = &g_own[g_own_count++];
+    }
+
+    /* Find session_id of the requesting fd */
+    uint32_t req_session = 0;
+    for (int i = 0; i < MAX_SESSIONS; i++) {
+        if (g_server->sessions[i].fd == fd) {
+            req_session = g_server->sessions[i].session_id;
+            break;
+        }
+    }
+
+    memcpy(e->sig_name, name, strlen(name) + 1);
+    e->session_id    = req_session;
+    e->client_fd     = fd;
+    e->locked        = 0;
+    e->on_disconnect = on_disc;
+
+    return send_own_ack(fd, name);
+}
+
+/* -------------------------------------------------------------------------
+ * OWN_RELEASE handler  (SPEC §8.2)
+ *
+ * Payload:
+ *   1B  name_len
+ *   NB  name
+ * ---------------------------------------------------------------------- */
+
+static int handle_own_release(int fd, const proto_frame_t *frame)
+{
+    if (frame->hdr.payload_len < 2u) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    const uint8_t *p         = frame->payload;
+    uint32_t       remaining = frame->hdr.payload_len;
+
+    char name[PROTO_MAX_NAME + 1];
+    if (parse_name(&p, &remaining, name) < 0) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    own_entry_t *e = own_find(name);
+
+    /* Determine requesting session_id */
+    uint32_t req_session = 0;
+    for (int i = 0; i < MAX_SESSIONS; i++) {
+        if (g_server->sessions[i].fd == fd) {
+            req_session = g_server->sessions[i].session_id;
+            break;
+        }
+    }
+
+    if (!e || e->session_id != req_session) {
+        proto_send_err(fd, ERR_OWN_NOT_HELD, NULL);
+        return 0;
+    }
+
+    e->session_id = 0;
+    e->client_fd  = -1;
+    e->locked     = 0;
+
+    return send_own_ack(fd, name);
+}
+
+/* -------------------------------------------------------------------------
+ * OWN_LOCK handler  (SPEC §8.3)
+ *
+ * Same payload as OWN_RELEASE.  Caller must own the signal.
+ * ---------------------------------------------------------------------- */
+
+static int handle_own_lock(int fd, const proto_frame_t *frame)
+{
+    if (frame->hdr.payload_len < 2u) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    const uint8_t *p         = frame->payload;
+    uint32_t       remaining = frame->hdr.payload_len;
+
+    char name[PROTO_MAX_NAME + 1];
+    if (parse_name(&p, &remaining, name) < 0) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    own_entry_t *e = own_find(name);
+
+    uint32_t req_session = 0;
+    for (int i = 0; i < MAX_SESSIONS; i++) {
+        if (g_server->sessions[i].fd == fd) {
+            req_session = g_server->sessions[i].session_id;
+            break;
+        }
+    }
+
+    if (!e || e->session_id != req_session) {
+        proto_send_err(fd, ERR_OWN_NOT_HELD, NULL);
+        return 0;
+    }
+
+    e->locked = 1;
+
+    return send_own_ack(fd, name);
+}
+
+/* -------------------------------------------------------------------------
+ * OWN_UNLOCK handler  (SPEC §8.3)
+ *
+ * Same payload as OWN_RELEASE.  Caller must own the signal.
+ * ---------------------------------------------------------------------- */
+
+static int handle_own_unlock(int fd, const proto_frame_t *frame)
+{
+    if (frame->hdr.payload_len < 2u) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    const uint8_t *p         = frame->payload;
+    uint32_t       remaining = frame->hdr.payload_len;
+
+    char name[PROTO_MAX_NAME + 1];
+    if (parse_name(&p, &remaining, name) < 0) {
+        proto_send_err(fd, ERR_DEF_INVALID, NULL);
+        return 0;
+    }
+
+    own_entry_t *e = own_find(name);
+
+    uint32_t req_session = 0;
+    for (int i = 0; i < MAX_SESSIONS; i++) {
+        if (g_server->sessions[i].fd == fd) {
+            req_session = g_server->sessions[i].session_id;
+            break;
+        }
+    }
+
+    if (!e || e->session_id != req_session) {
+        proto_send_err(fd, ERR_OWN_NOT_HELD, NULL);
+        return 0;
+    }
+
+    e->locked = 0;
+
+    return send_own_ack(fd, name);
+}
+
+/* -------------------------------------------------------------------------
+ * Session cleanup  (called from session_cleanup)
+ * ---------------------------------------------------------------------- */
+
+void own_session_cleanup(uint32_t session_id)
+{
+    for (int i = 0; i < g_own_count; i++) {
+        if (g_own[i].session_id == session_id) {
+            /*
+             * on_disconnect policy note: cyclic frame management (stop /
+             * last / default) will be enforced in the application-plane
+             * runtime (SPEC §10).  For now we simply release ownership so
+             * the signal becomes available for re-acquisition.
+             */
+            g_own[i].session_id = 0;
+            g_own[i].client_fd  = -1;
+            g_own[i].locked     = 0;
+        }
+    }
+}
+
+/* -------------------------------------------------------------------------
+ * Module lifecycle
+ * ---------------------------------------------------------------------- */
+
+void own_init(server_t *s)
+{
+    g_server    = s;
+    g_own_count = 0;
+}
+
+void own_destroy(void)
+{
+    g_own_count = 0;
+    g_server    = NULL;
+}
+
+void own_register_handlers(void)
+{
+    proto_register_handler(MSG_OWN_ACQUIRE, handle_own_acquire);
+    proto_register_handler(MSG_OWN_RELEASE, handle_own_release);
+    proto_register_handler(MSG_OWN_LOCK,    handle_own_lock);
+    proto_register_handler(MSG_OWN_UNLOCK,  handle_own_unlock);
+}

--- a/server/own.h
+++ b/server/own.h
@@ -1,0 +1,21 @@
+#ifndef ASH_SERVER_OWN_H
+#define ASH_SERVER_OWN_H
+
+/* -------------------------------------------------------------------------
+ * Signal ownership and ACL  (SPEC §8)
+ *
+ * Session-scoped ownership of signals.  At most one session may own a
+ * given signal at a time.  Ownership can be locked to prevent transfer.
+ * ---------------------------------------------------------------------- */
+
+#include "server.h"
+#include <stdint.h>
+
+void own_init(server_t *s);
+void own_destroy(void);
+void own_register_handlers(void);
+
+/* Release all signals owned by `session_id` (called from session_cleanup). */
+void own_session_cleanup(uint32_t session_id);
+
+#endif /* ASH_SERVER_OWN_H */

--- a/server/server.c
+++ b/server/server.c
@@ -3,6 +3,7 @@
 #include "session.h"
 #include "iface.h"
 #include "def.h"
+#include "own.h"
 
 #include <sys/epoll.h>
 #include <sys/signalfd.h>
@@ -196,6 +197,10 @@ int server_init(server_t *s, uint16_t port, const char *storage_dir)
     def_init();
     def_register_handlers();
 
+    /* --- Ownership module --- */
+    own_init(s);
+    own_register_handlers();
+
     printf("ash-server listening on port %u\n", (unsigned)port);
     return 0;
 }
@@ -358,6 +363,7 @@ void server_destroy(server_t *s)
         s->sessions[i].fd = -1;
     }
 
+    own_destroy();
     def_destroy();
     iface_destroy();
 

--- a/server/session.c
+++ b/server/session.c
@@ -1,6 +1,7 @@
 #include "session.h"
 #include "proto.h"
 #include "iface.h"
+#include "own.h"
 
 #include "ash/proto.h"
 
@@ -70,8 +71,10 @@ void session_arm_timer(session_t *sess)
 
 void session_cleanup(server_t *s, session_t *sess)
 {
-    if (sess->session_id != 0)
+    if (sess->session_id != 0) {
+        own_session_cleanup(sess->session_id);
         iface_session_cleanup(s, sess->session_id);
+    }
     sess->session_id = 0;
     memset(sess->client_name, 0, sizeof(sess->client_name));
 }

--- a/tools/test_client.py
+++ b/tools/test_client.py
@@ -11,6 +11,7 @@ Tests 1-7 run automatically.
 Tests 10-16 (CAN interface management) run automatically; the server must have
 CAP_NET_ADMIN (root) to create/destroy vcan interfaces.
 Tests 18-28 (definition store) run automatically.
+Tests 29-36 (signal ownership) run automatically.
 Test 8 (graceful server shutdown) requires manually stopping the server and
 must be requested with --test 8.
 Test 9 (keep-alive timeout) waits 30+ seconds and must be requested with --test 9.
@@ -167,6 +168,12 @@ MSG_NAMES = {
     0x0022: 'DEF_FRAME',
     0x0023: 'DEF_DELETE',
     0x8020: 'DEF_ACK',
+    0x0030: 'OWN_ACQUIRE',
+    0x0031: 'OWN_RELEASE',
+    0x0032: 'OWN_LOCK',
+    0x0033: 'OWN_UNLOCK',
+    0x8030: 'OWN_ACK',
+    0x9001: 'NOTIFY_OWN_REVOKED',
     0xFFFF: 'MSG_ERR',
 }
 
@@ -183,6 +190,8 @@ ERR_NAMES = {
     0x0020: 'ERR_DEF_INVALID',
     0x0021: 'ERR_DEF_CONFLICT',
     0x0022: 'ERR_DEF_IN_USE',
+    0x0030: 'ERR_OWN_NOT_AVAILABLE',
+    0x0031: 'ERR_OWN_NOT_HELD',
 }
 
 def fmt_type(t):
@@ -1185,6 +1194,330 @@ def test_def_persistence(host, port):
         def_cleanup(s2, ('t28_sig', DEF_TYPE_SIGNAL), ('t28_pdu', DEF_TYPE_PDU))
 
 
+# ── Ownership helpers ─────────────────────────────────────────────────────────
+
+MSG_OWN_ACQUIRE       = 0x0030
+MSG_OWN_RELEASE       = 0x0031
+MSG_OWN_LOCK          = 0x0032
+MSG_OWN_UNLOCK        = 0x0033
+MSG_OWN_ACK           = 0x8030
+MSG_NOTIFY_OWN_REVOKED = 0x9001
+
+ERR_OWN_NOT_AVAILABLE = 0x0030
+ERR_OWN_NOT_HELD      = 0x0031
+
+OWN_ON_DISC_STOP    = 0x01
+OWN_ON_DISC_LAST    = 0x02
+OWN_ON_DISC_DEFAULT = 0x03
+
+
+def make_own_acquire(sig_name, on_disconnect=OWN_ON_DISC_STOP):
+    n = sig_name.encode()
+    payload = bytes([len(n)]) + n + bytes([on_disconnect])
+    return make_frame(PROTO_VERSION, MSG_OWN_ACQUIRE, payload)
+
+
+def make_own_release(sig_name):
+    n = sig_name.encode()
+    payload = bytes([len(n)]) + n
+    return make_frame(PROTO_VERSION, MSG_OWN_RELEASE, payload)
+
+
+def make_own_lock(sig_name):
+    n = sig_name.encode()
+    payload = bytes([len(n)]) + n
+    return make_frame(PROTO_VERSION, MSG_OWN_LOCK, payload)
+
+
+def make_own_unlock(sig_name):
+    n = sig_name.encode()
+    payload = bytes([len(n)]) + n
+    return make_frame(PROTO_VERSION, MSG_OWN_UNLOCK, payload)
+
+
+def _define_signal(s, sig_name):
+    """Helper: define a signal and return True on success."""
+    s.sendall(make_def_signal(sig_name))
+    f = recv_frame(s)
+    return f is not None and f[1] == MSG_DEF_ACK
+
+
+def _delete_signal(s, sig_name):
+    """Helper: best-effort DEF_DELETE for a signal."""
+    s.sendall(make_def_delete(sig_name, DEF_TYPE_SIGNAL))
+    recv_frame(s)
+
+
+# ── Ownership tests (SPEC §8) ─────────────────────────────────────────────────
+
+def test_own_acquire(host, port):
+    """Test 29 — OWN_ACQUIRE on a defined signal → OWN_ACK."""
+    print('\n[29] OWN_ACQUIRE — define signal, acquire ownership, expect OWN_ACK')
+    with open_session(host, port, 'own-acquire-test')[0] as s:
+        if not _define_signal(s, 't29_sig'):
+            check(False, 'DEF_SIGNAL prerequisite failed')
+            return
+        s.sendall(make_own_acquire('t29_sig'))
+        frame = recv_frame(s)
+        print_response(frame)
+        if not check(frame is not None, 'received a response'):
+            _delete_signal(s, 't29_sig')
+            return
+        _, msg_type, _ = frame
+        check(msg_type == MSG_OWN_ACK,
+              f'response is OWN_ACK (got {fmt_type(msg_type)})')
+        s.sendall(make_own_release('t29_sig'))
+        recv_frame(s)
+        _delete_signal(s, 't29_sig')
+
+
+def test_own_release(host, port):
+    """Test 30 — OWN_RELEASE by owning session → OWN_ACK."""
+    print('\n[30] OWN_RELEASE — acquire then release, expect OWN_ACK')
+    with open_session(host, port, 'own-release-test')[0] as s:
+        if not _define_signal(s, 't30_sig'):
+            check(False, 'DEF_SIGNAL prerequisite failed')
+            return
+        s.sendall(make_own_acquire('t30_sig'))
+        if recv_frame(s) is None:
+            check(False, 'OWN_ACQUIRE prerequisite failed')
+            _delete_signal(s, 't30_sig')
+            return
+        s.sendall(make_own_release('t30_sig'))
+        frame = recv_frame(s)
+        print_response(frame)
+        if not check(frame is not None, 'received a response'):
+            _delete_signal(s, 't30_sig')
+            return
+        _, msg_type, _ = frame
+        check(msg_type == MSG_OWN_ACK,
+              f'response is OWN_ACK (got {fmt_type(msg_type)})')
+        _delete_signal(s, 't30_sig')
+
+
+def test_own_release_not_held(host, port):
+    """Test 31 — OWN_RELEASE without ownership → ERR_OWN_NOT_HELD."""
+    print('\n[31] OWN_RELEASE without ownership — expect ERR_OWN_NOT_HELD')
+    with open_session(host, port, 'own-release-notheld')[0] as s:
+        if not _define_signal(s, 't31_sig'):
+            check(False, 'DEF_SIGNAL prerequisite failed')
+            return
+        s.sendall(make_own_release('t31_sig'))
+        frame = recv_frame(s)
+        print_response(frame)
+        if not check(frame is not None, 'received a response'):
+            _delete_signal(s, 't31_sig')
+            return
+        _, msg_type, payload = frame
+        check(msg_type == MSG_ERR,
+              f'response is MSG_ERR (got {fmt_type(msg_type)})')
+        code, _ = decode_err(payload)
+        check(code == ERR_OWN_NOT_HELD,
+              f'err_code is ERR_OWN_NOT_HELD (got {fmt_err(code)})')
+        _delete_signal(s, 't31_sig')
+
+
+def test_own_transfer(host, port):
+    """Test 32 — Ownership transfer: session 2 acquires unlocked signal owned by session 1;
+    session 1 receives NOTIFY_OWN_REVOKED."""
+    print('\n[32] Ownership transfer — session 2 acquires session 1\'s unlocked signal;'
+          ' session 1 gets NOTIFY_OWN_REVOKED')
+    s1, _ = open_session(host, port, 'own-transfer-s1')
+    if s1 is None:
+        check(False, 'could not establish session 1')
+        return
+
+    try:
+        if not _define_signal(s1, 't32_sig'):
+            check(False, 'DEF_SIGNAL prerequisite failed')
+            return
+        s1.sendall(make_own_acquire('t32_sig'))
+        if recv_frame(s1) is None:
+            check(False, 'OWN_ACQUIRE prerequisite failed')
+            _delete_signal(s1, 't32_sig')
+            return
+
+        with open_session(host, port, 'own-transfer-s2')[0] as s2:
+            s2.sendall(make_own_acquire('t32_sig'))
+            ack = recv_frame(s2)
+            print_response(ack)
+            if not check(ack is not None, 'session 2 received a response to OWN_ACQUIRE'):
+                return
+            _, msg_type, _ = ack
+            check(msg_type == MSG_OWN_ACK,
+                  f'session 2 OWN_ACQUIRE succeeds (got {fmt_type(msg_type)})')
+
+            # Session 1 should receive NOTIFY_OWN_REVOKED
+            s1.settimeout(2)
+            try:
+                notif = recv_frame(s1)
+                print_response(notif)
+                if not check(notif is not None, 'session 1 received NOTIFY_OWN_REVOKED'):
+                    return
+                _, ntype, npayload = notif
+                check(ntype == MSG_NOTIFY_OWN_REVOKED,
+                      f'notification is NOTIFY_OWN_REVOKED (got {fmt_type(ntype)})')
+                if npayload:
+                    nlen = npayload[0]
+                    nname = npayload[1:1 + nlen].decode(errors='replace')
+                    check(nname == 't32_sig',
+                          f'notification names t32_sig (got {nname!r})')
+            except OSError:
+                check(False, 'session 1 timed out waiting for NOTIFY_OWN_REVOKED')
+
+            s2.sendall(make_own_release('t32_sig'))
+            recv_frame(s2)
+
+    finally:
+        _delete_signal(s1, 't32_sig')
+        s1.close()
+
+
+def test_own_locked_not_available(host, port):
+    """Test 33 — Locked signal cannot be acquired by another session → ERR_OWN_NOT_AVAILABLE."""
+    print('\n[33] OWN_ACQUIRE on locked signal — expect ERR_OWN_NOT_AVAILABLE')
+    s1, _ = open_session(host, port, 'own-lock-s1')
+    if s1 is None:
+        check(False, 'could not establish session 1')
+        return
+
+    try:
+        if not _define_signal(s1, 't33_sig'):
+            check(False, 'DEF_SIGNAL prerequisite failed')
+            return
+        s1.sendall(make_own_acquire('t33_sig'))
+        if recv_frame(s1) is None:
+            check(False, 'OWN_ACQUIRE prerequisite failed')
+            _delete_signal(s1, 't33_sig')
+            return
+        s1.sendall(make_own_lock('t33_sig'))
+        if recv_frame(s1) is None:
+            check(False, 'OWN_LOCK prerequisite failed')
+            _delete_signal(s1, 't33_sig')
+            return
+
+        with open_session(host, port, 'own-lock-s2')[0] as s2:
+            s2.sendall(make_own_acquire('t33_sig'))
+            frame = recv_frame(s2)
+            print_response(frame)
+            if not check(frame is not None, 'session 2 received a response'):
+                return
+            _, msg_type, payload = frame
+            check(msg_type == MSG_ERR,
+                  f'response is MSG_ERR (got {fmt_type(msg_type)})')
+            code, _ = decode_err(payload)
+            check(code == ERR_OWN_NOT_AVAILABLE,
+                  f'err_code is ERR_OWN_NOT_AVAILABLE (got {fmt_err(code)})')
+
+        # Cleanup: unlock and release before deleting
+        s1.sendall(make_own_unlock('t33_sig'))
+        recv_frame(s1)
+        s1.sendall(make_own_release('t33_sig'))
+        recv_frame(s1)
+        _delete_signal(s1, 't33_sig')
+
+    finally:
+        s1.close()
+
+
+def test_own_lock_unlock(host, port):
+    """Test 34 — OWN_LOCK / OWN_UNLOCK by owner → OWN_ACK each."""
+    print('\n[34] OWN_LOCK / OWN_UNLOCK by owner — expect OWN_ACK each')
+    with open_session(host, port, 'own-lock-unlock')[0] as s:
+        if not _define_signal(s, 't34_sig'):
+            check(False, 'DEF_SIGNAL prerequisite failed')
+            return
+        s.sendall(make_own_acquire('t34_sig'))
+        if recv_frame(s) is None:
+            check(False, 'OWN_ACQUIRE prerequisite failed')
+            _delete_signal(s, 't34_sig')
+            return
+
+        s.sendall(make_own_lock('t34_sig'))
+        frame = recv_frame(s)
+        print_response(frame)
+        if not check(frame is not None, 'received response to OWN_LOCK'):
+            _delete_signal(s, 't34_sig')
+            return
+        _, msg_type, _ = frame
+        check(msg_type == MSG_OWN_ACK,
+              f'OWN_LOCK → OWN_ACK (got {fmt_type(msg_type)})')
+
+        s.sendall(make_own_unlock('t34_sig'))
+        frame2 = recv_frame(s)
+        print_response(frame2)
+        if not check(frame2 is not None, 'received response to OWN_UNLOCK'):
+            _delete_signal(s, 't34_sig')
+            return
+        _, msg_type2, _ = frame2
+        check(msg_type2 == MSG_OWN_ACK,
+              f'OWN_UNLOCK → OWN_ACK (got {fmt_type(msg_type2)})')
+
+        s.sendall(make_own_release('t34_sig'))
+        recv_frame(s)
+        _delete_signal(s, 't34_sig')
+
+
+def test_own_lock_not_held(host, port):
+    """Test 35 — OWN_LOCK without ownership → ERR_OWN_NOT_HELD."""
+    print('\n[35] OWN_LOCK without ownership — expect ERR_OWN_NOT_HELD')
+    with open_session(host, port, 'own-lock-notheld')[0] as s:
+        if not _define_signal(s, 't35_sig'):
+            check(False, 'DEF_SIGNAL prerequisite failed')
+            return
+        s.sendall(make_own_lock('t35_sig'))
+        frame = recv_frame(s)
+        print_response(frame)
+        if not check(frame is not None, 'received a response'):
+            _delete_signal(s, 't35_sig')
+            return
+        _, msg_type, payload = frame
+        check(msg_type == MSG_ERR,
+              f'response is MSG_ERR (got {fmt_type(msg_type)})')
+        code, _ = decode_err(payload)
+        check(code == ERR_OWN_NOT_HELD,
+              f'err_code is ERR_OWN_NOT_HELD (got {fmt_err(code)})')
+        _delete_signal(s, 't35_sig')
+
+
+def test_own_session_close_releases(host, port):
+    """Test 36 — Session close releases ownership; another session can acquire."""
+    print('\n[36] Session close releases ownership — second session can acquire after first closes')
+    s1, _ = open_session(host, port, 'own-close-s1')
+    if s1 is None:
+        check(False, 'could not establish session 1')
+        return
+
+    try:
+        if not _define_signal(s1, 't36_sig'):
+            check(False, 'DEF_SIGNAL prerequisite failed')
+            return
+        s1.sendall(make_own_acquire('t36_sig'))
+        if recv_frame(s1) is None:
+            check(False, 'OWN_ACQUIRE prerequisite failed')
+            _delete_signal(s1, 't36_sig')
+            return
+        s1.sendall(make_frame(PROTO_VERSION, MSG_SESSION_CLOSE))
+        recv_frame(s1)
+    finally:
+        s1.close()
+
+    # New session: ownership now available
+    with open_session(host, port, 'own-close-s2')[0] as s2:
+        s2.sendall(make_own_acquire('t36_sig'))
+        frame = recv_frame(s2)
+        print_response(frame)
+        if not check(frame is not None, 'session 2 received a response'):
+            _delete_signal(s2, 't36_sig')
+            return
+        _, msg_type, _ = frame
+        check(msg_type == MSG_OWN_ACK,
+              f'ownership available after session close (got {fmt_type(msg_type)})')
+        s2.sendall(make_own_release('t36_sig'))
+        recv_frame(s2)
+        _delete_signal(s2, 't36_sig')
+
+
 # ── Entry point ───────────────────────────────────────────────────────────────
 
 TESTS = [
@@ -1216,9 +1549,17 @@ TESTS = [
     test_def_pdu_signal_count_limit,    # 26
     test_def_frame_pdu_count_limit,     # 27
     test_def_persistence,               # 28
+    test_own_acquire,                   # 29
+    test_own_release,                   # 30
+    test_own_release_not_held,          # 31
+    test_own_transfer,                  # 32
+    test_own_locked_not_available,      # 33
+    test_own_lock_unlock,               # 34
+    test_own_lock_not_held,             # 35
+    test_own_session_close_releases,    # 36
 ]
 
-AUTO_TESTS = TESTS[:7] + TESTS[9:16] + TESTS[17:]  # 1-7, 10-16, and 18-28 run unattended
+AUTO_TESTS = TESTS[:7] + TESTS[9:16] + TESTS[17:]  # 1-7, 10-16, and 18-36 run unattended
 
 
 def main():


### PR DESCRIPTION
## Summary

- Add `server/own.c` and `server/own.h` implementing the four ownership handlers: `OWN_ACQUIRE`, `OWN_RELEASE`, `OWN_LOCK`, `OWN_UNLOCK`
- Global ownership table (`g_own[512]`): per-signal record holding session_id, client_fd, locked flag, and on_disconnect policy
- `own_session_cleanup()` integrated into `session_cleanup()` — releases all signals on close or timeout

## Details

- **OWN_ACQUIRE**: assigns free signal to caller; if owned by another unlocked session, transfers ownership and sends `NOTIFY_OWN_REVOKED` to previous owner; re-acquire by same session updates `on_disconnect`; locked signal returns `ERR_OWN_NOT_AVAILABLE`
- **OWN_RELEASE**: releases signal; returns `ERR_OWN_NOT_HELD` if caller does not own it
- **OWN_LOCK / OWN_UNLOCK**: set/clear locked flag; return `ERR_OWN_NOT_HELD` if caller does not own the signal
- `def_signal_exists()` exposed from `def` module to validate signal existence before granting ownership
- `on_disconnect` policy stored per entry; cyclic frame enforcement deferred to issue #11

## Test plan (tests 29–36)

- [x] `OWN_ACQUIRE` on defined signal → `OWN_ACK`
- [x] `OWN_RELEASE` by owner → `OWN_ACK`
- [x] `OWN_RELEASE` without ownership → `ERR_OWN_NOT_HELD`
- [x] Ownership transfer: session 2 acquires, session 1 gets `NOTIFY_OWN_REVOKED`
- [x] `OWN_ACQUIRE` on locked signal → `ERR_OWN_NOT_AVAILABLE`
- [x] `OWN_LOCK` / `OWN_UNLOCK` by owner → `OWN_ACK` each
- [x] `OWN_LOCK` without ownership → `ERR_OWN_NOT_HELD`
- [x] Session close releases ownership; second session can acquire

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)