### PR TITLE
#28: handle missing CAP_NET_ADMIN gracefully

### DIFF
--- a/include/ash/proto.h
+++ b/include/ash/proto.h
@@ -95,6 +95,7 @@ typedef struct {
 #define ERR_IFACE_NOT_FOUND         0x0010u
 #define ERR_IFACE_ALREADY_ATTACHED  0x0011u
 #define ERR_IFACE_ATTACH_FAILED     0x0012u
+#define ERR_PERMISSION_DENIED       0x0013u
 #define ERR_DEF_INVALID             0x0020u
 #define ERR_DEF_CONFLICT            0x0021u
 #define ERR_DEF_IN_USE              0x0022u

--- a/server/iface.c
+++ b/server/iface.c
@@ -606,6 +606,12 @@ static int handle_iface_attach(int fd, const proto_frame_t *frame)
         return 0;
     }
 
+    /* Bitrate configuration requires CAP_NET_ADMIN */
+    if (bitrate != 0 && !g_server->has_cap_net_admin) {
+        proto_send_err(fd, ERR_PERMISSION_DENIED, NULL);
+        return 0;
+    }
+
     /* Optionally configure bitrate */
     if (bitrate != 0 && iface_set_bitrate(name, bitrate) < 0)
         fprintf(stderr, "ash-server: bitrate config failed for %s (continuing)\n",
@@ -759,6 +765,11 @@ static int handle_iface_vcan_create(int fd, const proto_frame_t *frame)
     memcpy(name, &frame->payload[1], name_len);
     name[name_len] = '\0';
 
+    if (!g_server->has_cap_net_admin) {
+        proto_send_err(fd, ERR_PERMISSION_DENIED, NULL);
+        return 0;
+    }
+
     if (vcan_create(name) < 0) {
         fprintf(stderr, "ash-server: vcan_create(%s) failed: %s\n",
                 name, strerror(errno));
@@ -794,6 +805,11 @@ static int handle_iface_vcan_destroy(int fd, const proto_frame_t *frame)
     char name[PROTO_MAX_NAME + 1];
     memcpy(name, &frame->payload[1], name_len);
     name[name_len] = '\0';
+
+    if (!g_server->has_cap_net_admin) {
+        proto_send_err(fd, ERR_PERMISSION_DENIED, NULL);
+        return 0;
+    }
 
     if (vcan_destroy(name) < 0) {
         proto_send_err(fd, ERR_IFACE_NOT_FOUND, NULL);

--- a/server/server.c
+++ b/server/server.c
@@ -17,6 +17,30 @@
 #include <errno.h>
 
 /* -------------------------------------------------------------------------
+ * CAP_NET_ADMIN probe  (reads /proc/self/status — no libcap dependency)
+ * ---------------------------------------------------------------------- */
+
+static uint8_t probe_cap_net_admin(void)
+{
+    FILE *f = fopen("/proc/self/status", "r");
+    if (!f)
+        return 0;
+
+    char line[256];
+    unsigned long long capeff = 0;
+    while (fgets(line, sizeof(line), f)) {
+        if (strncmp(line, "CapEff:", 7) == 0) {
+            sscanf(line + 7, "%llx", &capeff);
+            break;
+        }
+    }
+    fclose(f);
+
+    /* CAP_NET_ADMIN is bit 12 of the effective capability set */
+    return (uint8_t)((capeff >> 12) & 1u);
+}
+
+/* -------------------------------------------------------------------------
  * Static helpers
  * ---------------------------------------------------------------------- */
 
@@ -184,6 +208,13 @@ int server_init(server_t *s, uint16_t port, const char *storage_dir)
 
     if (server_add_fd(s, s->listen_fd, EPOLLIN) < 0)
         return -1;
+
+    /* --- Capability check --- */
+    s->has_cap_net_admin = probe_cap_net_admin();
+    if (!s->has_cap_net_admin)
+        fprintf(stderr,
+                "ash-server: warning: CAP_NET_ADMIN not held — "
+                "vcan create/destroy and bitrate configuration unavailable\n");
 
     /* --- Session module --- */
     session_set_server(s);

--- a/server/server.h
+++ b/server/server.h
@@ -20,9 +20,10 @@ typedef struct {
     int         epoll_fd;
     int         listen_fd;
     int         signal_fd;
-    int         netlink_fd;   /* RTMGRP_LINK monitoring socket (-1 if unused) */
+    int         netlink_fd;        /* RTMGRP_LINK monitoring socket (-1 if unused) */
     const char *storage_dir;
     uint16_t    port;
+    uint8_t     has_cap_net_admin; /* 1 if server holds CAP_NET_ADMIN */
     session_t   sessions[MAX_SESSIONS];
     int         nsessions;
 } server_t;

--- a/tools/test_client.py
+++ b/tools/test_client.py
@@ -12,6 +12,8 @@ Tests 10-16 (CAN interface management) run automatically; the server must have
 CAP_NET_ADMIN (root) to create/destroy vcan interfaces.
 Tests 18-28 (definition store) run automatically.
 Tests 29-36 (signal ownership) run automatically.
+Tests 37-39 (CAP_NET_ADMIN) run automatically; they self-skip when the server
+holds CAP_NET_ADMIN.
 Test 8 (graceful server shutdown) requires manually stopping the server and
 must be requested with --test 8.
 Test 9 (keep-alive timeout) waits 30+ seconds and must be requested with --test 9.
@@ -187,6 +189,7 @@ ERR_NAMES = {
     0x0010: 'ERR_IFACE_NOT_FOUND',
     0x0011: 'ERR_IFACE_ALREADY_ATTACHED',
     0x0012: 'ERR_IFACE_ATTACH_FAILED',
+    0x0013: 'ERR_PERMISSION_DENIED',
     0x0020: 'ERR_DEF_INVALID',
     0x0021: 'ERR_DEF_CONFLICT',
     0x0022: 'ERR_DEF_IN_USE',
@@ -1518,6 +1521,108 @@ def test_own_session_close_releases(host, port):
         _delete_signal(s2, 't36_sig')
 
 
+# ── CAP_NET_ADMIN tests ───────────────────────────────────────────────────────
+
+ERR_PERMISSION_DENIED = 0x0013
+
+
+def test_cap_net_admin_vcan_create(host, port):
+    """Test 37 — IFACE_VCAN_CREATE without CAP_NET_ADMIN → ERR_PERMISSION_DENIED.
+
+    Skipped automatically when the server holds CAP_NET_ADMIN (operation
+    succeeds instead and is cleaned up).
+    """
+    print('\n[37] IFACE_VCAN_CREATE without CAP_NET_ADMIN — expect ERR_PERMISSION_DENIED'
+          ' (skipped if server has CAP_NET_ADMIN)')
+    with open_session(host, port, 'cap-vcan-create')[0] as s:
+        s.sendall(make_iface_vcan_create(TEST_VCAN))
+        frame = recv_frame(s)
+        print_response(frame)
+        if not check(frame is not None, 'received a response'):
+            return
+        _, msg_type, payload = frame
+        if msg_type == MSG_IFACE_VCAN_ACK:
+            print('  [skip] server holds CAP_NET_ADMIN')
+            s.sendall(make_iface_vcan_destroy(TEST_VCAN))
+            recv_frame(s)
+            return
+        check(msg_type == MSG_ERR,
+              f'response is MSG_ERR (got {fmt_type(msg_type)})')
+        code, _ = decode_err(payload)
+        check(code == ERR_PERMISSION_DENIED,
+              f'err_code is ERR_PERMISSION_DENIED (got {fmt_err(code)})')
+
+
+def test_cap_net_admin_vcan_destroy(host, port):
+    """Test 38 — IFACE_VCAN_DESTROY without CAP_NET_ADMIN → ERR_PERMISSION_DENIED.
+
+    Skipped automatically when the server holds CAP_NET_ADMIN.
+    """
+    print('\n[38] IFACE_VCAN_DESTROY without CAP_NET_ADMIN — expect ERR_PERMISSION_DENIED'
+          ' (skipped if server has CAP_NET_ADMIN)')
+    with open_session(host, port, 'cap-vcan-destroy')[0] as s:
+        s.sendall(make_iface_vcan_destroy(TEST_VCAN))
+        frame = recv_frame(s)
+        print_response(frame)
+        if not check(frame is not None, 'received a response'):
+            return
+        _, msg_type, payload = frame
+        if msg_type == MSG_IFACE_VCAN_ACK:
+            print('  [skip] server holds CAP_NET_ADMIN')
+            return
+        check(msg_type == MSG_ERR,
+              f'response is MSG_ERR (got {fmt_type(msg_type)})')
+        code, _ = decode_err(payload)
+        check(code == ERR_PERMISSION_DENIED,
+              f'err_code is ERR_PERMISSION_DENIED (got {fmt_err(code)})')
+
+
+def test_cap_net_admin_attach_bitrate(host, port):
+    """Test 39 — IFACE_ATTACH with non-zero bitrate without CAP_NET_ADMIN →
+    ERR_PERMISSION_DENIED.
+
+    Uses IFACE_VCAN_CREATE as a capability probe: if it succeeds the server
+    holds CAP_NET_ADMIN and the test is skipped.  If the server lacks the
+    capability, attempts IFACE_ATTACH with bitrate=500000 on any listed
+    interface and expects ERR_PERMISSION_DENIED.
+    """
+    print('\n[39] IFACE_ATTACH with bitrate≠0 without CAP_NET_ADMIN — expect ERR_PERMISSION_DENIED'
+          ' (skipped if server has CAP_NET_ADMIN)')
+    with open_session(host, port, 'cap-attach-bitrate')[0] as s:
+        # Probe capability via VCAN_CREATE
+        s.sendall(make_iface_vcan_create('cap_probe99'))
+        probe = recv_frame(s)
+        if probe and probe[1] == MSG_IFACE_VCAN_ACK:
+            print('  [skip] server holds CAP_NET_ADMIN')
+            s.sendall(make_iface_vcan_destroy('cap_probe99'))
+            recv_frame(s)
+            return
+
+        # Server lacks CAP_NET_ADMIN — find any interface to test with
+        s.sendall(make_iface_list())
+        list_frame = recv_frame(s)
+        if list_frame is None or list_frame[1] != MSG_IFACE_LIST_RESP:
+            print('  [skip] could not list interfaces')
+            return
+        ifaces = parse_iface_list_resp(list_frame[2])
+        if not ifaces:
+            print('  [skip] no interfaces available')
+            return
+
+        iface_name, _ = ifaces[0]
+        s.sendall(make_iface_attach(iface_name, bitrate=500000))
+        frame = recv_frame(s)
+        print_response(frame)
+        if not check(frame is not None, 'received a response'):
+            return
+        _, msg_type, payload = frame
+        check(msg_type == MSG_ERR,
+              f'response is MSG_ERR (got {fmt_type(msg_type)})')
+        code, _ = decode_err(payload)
+        check(code == ERR_PERMISSION_DENIED,
+              f'err_code is ERR_PERMISSION_DENIED (got {fmt_err(code)})')
+
+
 # ── Entry point ───────────────────────────────────────────────────────────────
 
 TESTS = [
@@ -1557,9 +1662,12 @@ TESTS = [
     test_own_lock_unlock,               # 34
     test_own_lock_not_held,             # 35
     test_own_session_close_releases,    # 36
+    test_cap_net_admin_vcan_create,     # 37
+    test_cap_net_admin_vcan_destroy,    # 38
+    test_cap_net_admin_attach_bitrate,  # 39
 ]
 
-AUTO_TESTS = TESTS[:7] + TESTS[9:16] + TESTS[17:]  # 1-7, 10-16, and 18-36 run unattended
+AUTO_TESTS = TESTS[:7] + TESTS[9:16] + TESTS[17:]  # 1-7, 10-16, and 18-39 run unattended
 
 
 def main():


### PR DESCRIPTION
## Summary

- Probe `CAP_NET_ADMIN` at startup via `/proc/self/status` (no libcap dependency); log a clear warning when absent
- Add `ERR_PERMISSION_DENIED` (`0x0013`) to the wire protocol
- Gate the three operations that require the capability; all other iface operations continue to work unprivileged

## Changes

| File | Change |
|------|--------|
| `include/ash/proto.h` | Add `ERR_PERMISSION_DENIED = 0x0013u` |
| `server/server.h` | Add `has_cap_net_admin` field to `server_t` |
| `server/server.c` | `probe_cap_net_admin()` reads `CapEff` from `/proc/self/status`; stored and warning logged in `server_init` |
| `server/iface.c` | `IFACE_VCAN_CREATE`, `IFACE_VCAN_DESTROY`, `IFACE_ATTACH` (bitrate≠0) return `ERR_PERMISSION_DENIED` when flag is unset |

## Test plan (tests 37–39)

Tests self-skip when the server holds `CAP_NET_ADMIN` (they detect this via a `VCAN_CREATE` probe), so they're safe to run in both environments.

- [ ] `IFACE_VCAN_CREATE` without cap → `ERR_PERMISSION_DENIED`
- [ ] `IFACE_VCAN_DESTROY` without cap → `ERR_PERMISSION_DENIED`
- [ ] `IFACE_ATTACH` with `bitrate=500000` without cap → `ERR_PERMISSION_DENIED`
- [ ] `IFACE_LIST` and `IFACE_ATTACH` with `bitrate=0` work without cap (covered by existing tests 11–12 which run without requiring cap)
- [ ] Server logs startup warning when cap is absent

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)