### PR TITLE
#12: Configuration persistence (SPEC §9)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ add_compile_options($<$<CONFIG:Debug>:-Wall>
 include_directories(include)
 
 # Server
-add_executable(ash-server server/main.c server/server.c server/proto.c server/session.c server/iface.c server/def.c server/own.c)
+add_executable(ash-server server/main.c server/server.c server/proto.c server/session.c server/iface.c server/def.c server/own.c server/cfg.c)
 target_compile_definitions(ash-server PRIVATE _GNU_SOURCE)
 
 # Client library

--- a/server/cfg.c
+++ b/server/cfg.c
@@ -1,0 +1,367 @@
+#include "cfg.h"
+#include "def.h"
+#include "proto.h"
+
+#include "ash/proto.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <dirent.h>
+#include <limits.h>
+#include <errno.h>
+
+/* -------------------------------------------------------------------------
+ * CRC32  (IEEE 802.3, polynomial 0xEDB88320)
+ * ---------------------------------------------------------------------- */
+
+static uint32_t g_crc_table[256];
+static int      g_crc_table_ready = 0;
+
+static void crc32_init(void)
+{
+    for (uint32_t i = 0; i < 256u; i++) {
+        uint32_t c = i;
+        for (int j = 0; j < 8; j++)
+            c = (c & 1u) ? (0xEDB88320u ^ (c >> 1)) : (c >> 1);
+        g_crc_table[i] = c;
+    }
+    g_crc_table_ready = 1;
+}
+
+static uint32_t crc32_compute(const uint8_t *data, size_t len)
+{
+    if (!g_crc_table_ready)
+        crc32_init();
+    uint32_t crc = 0xFFFFFFFFu;
+    for (size_t i = 0; i < len; i++)
+        crc = g_crc_table[(crc ^ data[i]) & 0xFFu] ^ (crc >> 8);
+    return crc ^ 0xFFFFFFFFu;
+}
+
+/* -------------------------------------------------------------------------
+ * File format constants  (SPEC §9.2)
+ * ---------------------------------------------------------------------- */
+
+#define CFG_MAGIC        0x41534843u   /* "ASHC" */
+#define CFG_VERSION      0x0001u
+#define CFG_HEADER_SIZE  12u           /* magic(4)+version(2)+count(2)+crc32(4) */
+#define CFG_MAX_BUF      (1u << 20)    /* 1 MiB — generous upper bound */
+
+/* -------------------------------------------------------------------------
+ * Module state
+ * ---------------------------------------------------------------------- */
+
+static const char *g_storage_dir = NULL;
+
+/* -------------------------------------------------------------------------
+ * Path helper
+ * ---------------------------------------------------------------------- */
+
+static int build_path(char *out, size_t outsz, const char *name)
+{
+    if (strchr(name, '/') || strchr(name, '\\'))
+        return -1;
+    int r = snprintf(out, outsz, "%s/%s.ashcfg", g_storage_dir, name);
+    if (r < 0 || (size_t)r >= outsz)
+        return -1;
+    return 0;
+}
+
+/* -------------------------------------------------------------------------
+ * load_file — internal: read, validate, conflict-check, apply
+ * ---------------------------------------------------------------------- */
+
+static int load_file(const char *path, uint16_t *err_code)
+{
+    FILE *f = fopen(path, "rb");
+    if (!f) {
+        *err_code = ERR_CFG_IO;
+        return -1;
+    }
+
+    if (fseek(f, 0, SEEK_END) != 0) {
+        fclose(f);
+        *err_code = ERR_CFG_IO;
+        return -1;
+    }
+    long fsize = ftell(f);
+    rewind(f);
+
+    if (fsize < (long)CFG_HEADER_SIZE || fsize > (long)CFG_MAX_BUF) {
+        fclose(f);
+        *err_code = ERR_CFG_IO;
+        return -1;
+    }
+
+    uint8_t *buf = malloc((size_t)fsize);
+    if (!buf) {
+        fclose(f);
+        *err_code = ERR_CFG_IO;
+        return -1;
+    }
+
+    if (fread(buf, 1, (size_t)fsize, f) != (size_t)fsize) {
+        free(buf);
+        fclose(f);
+        *err_code = ERR_CFG_IO;
+        return -1;
+    }
+    fclose(f);
+
+    /* Parse header */
+    uint32_t magic   = ((uint32_t)buf[0] << 24) | ((uint32_t)buf[1] << 16)
+                     | ((uint32_t)buf[2] <<  8) |  (uint32_t)buf[3];
+    uint16_t version = ((uint16_t)buf[4] << 8) | buf[5];
+    uint16_t count   = ((uint16_t)buf[6] << 8) | buf[7];
+    uint32_t stored_crc = ((uint32_t)buf[8]  << 24) | ((uint32_t)buf[9]  << 16)
+                        | ((uint32_t)buf[10] <<  8) |  (uint32_t)buf[11];
+
+    if (magic != CFG_MAGIC || version != CFG_VERSION) {
+        free(buf);
+        *err_code = ERR_CFG_IO;
+        return -1;
+    }
+
+    /* CRC covers all bytes after the CRC field (offset 12 onward) */
+    uint32_t calc_crc = crc32_compute(buf + CFG_HEADER_SIZE,
+                                      (size_t)fsize - CFG_HEADER_SIZE);
+    if (calc_crc != stored_crc) {
+        free(buf);
+        *err_code = ERR_CFG_CHECKSUM;
+        return -1;
+    }
+
+    /* Phase 1: conflict-check every entry */
+    size_t pos = CFG_HEADER_SIZE;
+    for (uint16_t i = 0; i < count; i++) {
+        if (pos + 3u > (size_t)fsize) {
+            free(buf);
+            *err_code = ERR_CFG_IO;
+            return -1;
+        }
+        uint8_t  entry_type = buf[pos];
+        uint16_t entry_len  = ((uint16_t)buf[pos+1] << 8) | buf[pos+2];
+        pos += 3;
+
+        if (pos + entry_len > (size_t)fsize) {
+            free(buf);
+            *err_code = ERR_CFG_IO;
+            return -1;
+        }
+
+        int rc = def_validate_entry(entry_type, buf + pos, entry_len);
+        if (rc == DEF_APPLY_CONFLICT) {
+            free(buf);
+            *err_code = ERR_CFG_CONFLICT;
+            return -1;
+        }
+        if (rc == DEF_APPLY_INVALID) {
+            free(buf);
+            *err_code = ERR_CFG_IO;
+            return -1;
+        }
+
+        pos += entry_len;
+    }
+
+    /* Phase 2: apply all entries */
+    pos = CFG_HEADER_SIZE;
+    for (uint16_t i = 0; i < count; i++) {
+        uint8_t  entry_type = buf[pos];
+        uint16_t entry_len  = ((uint16_t)buf[pos+1] << 8) | buf[pos+2];
+        pos += 3;
+        def_apply_entry(entry_type, buf + pos, entry_len);
+        pos += entry_len;
+    }
+
+    free(buf);
+    return 0;
+}
+
+/* -------------------------------------------------------------------------
+ * CFG_SAVE handler  (SPEC §9.3)
+ * ---------------------------------------------------------------------- */
+
+static int handle_cfg_save(int fd, const proto_frame_t *frame)
+{
+    if (!g_storage_dir) {
+        proto_send_err(fd, ERR_CFG_IO, NULL);
+        return 0;
+    }
+
+    if (frame->hdr.payload_len < 2u) {
+        proto_send_err(fd, ERR_CFG_IO, NULL);
+        return 0;
+    }
+
+    uint8_t name_len = frame->payload[0];
+    if (name_len == 0 || name_len > PROTO_MAX_NAME ||
+        frame->hdr.payload_len < (uint32_t)(1u + name_len)) {
+        proto_send_err(fd, ERR_CFG_IO, NULL);
+        return 0;
+    }
+
+    char name[PROTO_MAX_NAME + 1];
+    memcpy(name, frame->payload + 1, name_len);
+    name[name_len] = '\0';
+
+    char path[PATH_MAX];
+    if (build_path(path, sizeof(path), name) < 0) {
+        proto_send_err(fd, ERR_CFG_IO, NULL);
+        return 0;
+    }
+
+    /* Serialize definitions into a heap buffer (header + body) */
+    uint8_t *buf = malloc(CFG_MAX_BUF);
+    if (!buf) {
+        proto_send_err(fd, ERR_CFG_IO, NULL);
+        return 0;
+    }
+
+    uint16_t entry_count = 0;
+    ssize_t  body_len    = def_serialize_entries(buf + CFG_HEADER_SIZE,
+                                                 CFG_MAX_BUF - CFG_HEADER_SIZE,
+                                                 &entry_count);
+    if (body_len < 0) {
+        free(buf);
+        proto_send_err(fd, ERR_CFG_IO, NULL);
+        return 0;
+    }
+
+    /* CRC32 of the body */
+    uint32_t crc = crc32_compute(buf + CFG_HEADER_SIZE, (size_t)body_len);
+
+    /* Write file header */
+    buf[0]  = (uint8_t)((CFG_MAGIC >> 24) & 0xFF);
+    buf[1]  = (uint8_t)((CFG_MAGIC >> 16) & 0xFF);
+    buf[2]  = (uint8_t)((CFG_MAGIC >>  8) & 0xFF);
+    buf[3]  = (uint8_t)( CFG_MAGIC        & 0xFF);
+    buf[4]  = (uint8_t)((CFG_VERSION >> 8) & 0xFF);
+    buf[5]  = (uint8_t)( CFG_VERSION       & 0xFF);
+    buf[6]  = (uint8_t)((entry_count >> 8) & 0xFF);
+    buf[7]  = (uint8_t)( entry_count       & 0xFF);
+    buf[8]  = (uint8_t)((crc >> 24) & 0xFF);
+    buf[9]  = (uint8_t)((crc >> 16) & 0xFF);
+    buf[10] = (uint8_t)((crc >>  8) & 0xFF);
+    buf[11] = (uint8_t)( crc        & 0xFF);
+
+    FILE *outf = fopen(path, "wb");
+    if (!outf) {
+        free(buf);
+        proto_send_err(fd, ERR_CFG_IO, NULL);
+        return 0;
+    }
+
+    size_t total = CFG_HEADER_SIZE + (size_t)body_len;
+    if (fwrite(buf, 1, total, outf) != total) {
+        fclose(outf);
+        free(buf);
+        proto_send_err(fd, ERR_CFG_IO, NULL);
+        return 0;
+    }
+
+    fclose(outf);
+    free(buf);
+
+    return proto_send_ack(fd, MSG_CFG_ACK, NULL, 0);
+}
+
+/* -------------------------------------------------------------------------
+ * CFG_LOAD handler  (SPEC §9.4)
+ * ---------------------------------------------------------------------- */
+
+static int handle_cfg_load(int fd, const proto_frame_t *frame)
+{
+    if (!g_storage_dir) {
+        proto_send_err(fd, ERR_CFG_IO, NULL);
+        return 0;
+    }
+
+    if (frame->hdr.payload_len < 2u) {
+        proto_send_err(fd, ERR_CFG_IO, NULL);
+        return 0;
+    }
+
+    uint8_t name_len = frame->payload[0];
+    if (name_len == 0 || name_len > PROTO_MAX_NAME ||
+        frame->hdr.payload_len < (uint32_t)(1u + name_len)) {
+        proto_send_err(fd, ERR_CFG_IO, NULL);
+        return 0;
+    }
+
+    char name[PROTO_MAX_NAME + 1];
+    memcpy(name, frame->payload + 1, name_len);
+    name[name_len] = '\0';
+
+    char path[PATH_MAX];
+    if (build_path(path, sizeof(path), name) < 0) {
+        proto_send_err(fd, ERR_CFG_IO, NULL);
+        return 0;
+    }
+
+    uint16_t err_code = ERR_CFG_IO;
+    if (load_file(path, &err_code) < 0) {
+        proto_send_err(fd, err_code, NULL);
+        return 0;
+    }
+
+    return proto_send_ack(fd, MSG_CFG_ACK, NULL, 0);
+}
+
+/* -------------------------------------------------------------------------
+ * Module init / registration / autoload
+ * ---------------------------------------------------------------------- */
+
+void cfg_init(const char *storage_dir)
+{
+    g_storage_dir = storage_dir;
+}
+
+void cfg_register_handlers(void)
+{
+    proto_register_handler(MSG_CFG_SAVE, handle_cfg_save);
+    proto_register_handler(MSG_CFG_LOAD, handle_cfg_load);
+}
+
+void cfg_autoload(void)
+{
+    if (!g_storage_dir)
+        return;
+
+    DIR *dir = opendir(g_storage_dir);
+    if (!dir) {
+        if (errno != ENOENT)
+            fprintf(stderr,
+                    "ash-server: cfg_autoload: cannot open storage dir '%s': %s\n",
+                    g_storage_dir, strerror(errno));
+        return;
+    }
+
+    struct dirent *ent;
+    while ((ent = readdir(dir)) != NULL) {
+        const char *dname = ent->d_name;
+        size_t      dlen  = strlen(dname);
+
+        /* Must end with ".ashcfg" (7 chars) and have at least one char before */
+        if (dlen < 8 || strcmp(dname + dlen - 7, ".ashcfg") != 0)
+            continue;
+
+        char path[PATH_MAX];
+        int r = snprintf(path, sizeof(path), "%s/%s", g_storage_dir, dname);
+        if (r < 0 || (size_t)r >= sizeof(path))
+            continue;
+
+        uint16_t err_code = ERR_CFG_IO;
+        if (load_file(path, &err_code) < 0) {
+            fprintf(stderr,
+                    "ash-server: cfg_autoload: failed to load '%s' (err=0x%04X)\n",
+                    path, err_code);
+        } else {
+            printf("ash-server: cfg_autoload: loaded '%s'\n", path);
+        }
+    }
+
+    closedir(dir);
+}

--- a/server/cfg.h
+++ b/server/cfg.h
@@ -1,0 +1,25 @@
+#ifndef ASH_SERVER_CFG_H
+#define ASH_SERVER_CFG_H
+
+/* -------------------------------------------------------------------------
+ * Configuration persistence  (SPEC §9)
+ *
+ * Saves and loads the global definition store to/from binary .ashcfg files.
+ * ---------------------------------------------------------------------- */
+
+/*
+ * cfg_init: record the storage directory (NULL = persistence disabled).
+ * Must be called before cfg_register_handlers() and cfg_autoload().
+ */
+void cfg_init(const char *storage_dir);
+
+/* Register CFG_SAVE / CFG_LOAD message handlers with the dispatch table. */
+void cfg_register_handlers(void);
+
+/*
+ * cfg_autoload: load every *.ashcfg file found in the storage directory
+ * into the global definition store.  Called once at server startup.
+ */
+void cfg_autoload(void);
+
+#endif /* ASH_SERVER_CFG_H */

--- a/server/def.c
+++ b/server/def.c
@@ -149,8 +149,22 @@ static int pdu_has_dependents(const char *pdu_name)
 }
 
 /* -------------------------------------------------------------------------
- * Wire read helper for IEEE 754 doubles stored big-endian
+ * Wire helpers for IEEE 754 doubles (read/write big-endian)
  * ---------------------------------------------------------------------- */
+
+static void write_be_double(uint8_t *p, double d)
+{
+    uint64_t raw;
+    memcpy(&raw, &d, sizeof(raw));
+    p[0] = (uint8_t)((raw >> 56) & 0xFF);
+    p[1] = (uint8_t)((raw >> 48) & 0xFF);
+    p[2] = (uint8_t)((raw >> 40) & 0xFF);
+    p[3] = (uint8_t)((raw >> 32) & 0xFF);
+    p[4] = (uint8_t)((raw >> 24) & 0xFF);
+    p[5] = (uint8_t)((raw >> 16) & 0xFF);
+    p[6] = (uint8_t)((raw >>  8) & 0xFF);
+    p[7] = (uint8_t)( raw        & 0xFF);
+}
 
 static double read_be_double(const uint8_t *p)
 {
@@ -605,4 +619,316 @@ void def_register_handlers(void)
     proto_register_handler(MSG_DEF_PDU,    handle_def_pdu);
     proto_register_handler(MSG_DEF_FRAME,  handle_def_frame);
     proto_register_handler(MSG_DEF_DELETE, handle_def_delete);
+}
+
+/* -------------------------------------------------------------------------
+ * Serialization helpers
+ * ---------------------------------------------------------------------- */
+
+static int buf_write(uint8_t *buf, size_t bufsz, size_t *pos,
+                     const void *data, size_t len)
+{
+    if (*pos + len > bufsz)
+        return -1;
+    memcpy(buf + *pos, data, len);
+    *pos += len;
+    return 0;
+}
+
+static int buf_write1(uint8_t *buf, size_t bufsz, size_t *pos, uint8_t b)
+{
+    return buf_write(buf, bufsz, pos, &b, 1);
+}
+
+/* -------------------------------------------------------------------------
+ * def_serialize_entries  (SPEC §9.2)
+ * ---------------------------------------------------------------------- */
+
+ssize_t def_serialize_entries(uint8_t *buf, size_t bufsize, uint16_t *count_out)
+{
+    size_t   pos   = 0;
+    uint16_t count = 0;
+
+    /* ── Signals ── */
+    for (int i = 0; i < g_signal_count; i++) {
+        const signal_def_t *s = &g_signals[i];
+        uint8_t name_len = (uint8_t)strlen(s->name);
+
+        if (buf_write1(buf, bufsize, &pos, DEF_TYPE_SIGNAL) < 0) return -1;
+        size_t len_pos = pos; pos += 2;   /* reserve payload-length field */
+        if (pos > bufsize) return -1;
+        size_t payload_start = pos;
+
+        if (buf_write1(buf, bufsize, &pos, name_len)            < 0) return -1;
+        if (buf_write(buf, bufsize, &pos, s->name, name_len)    < 0) return -1;
+        if (buf_write1(buf, bufsize, &pos, s->data_type)        < 0) return -1;
+        if (buf_write1(buf, bufsize, &pos, s->byte_order)       < 0) return -1;
+        if (buf_write1(buf, bufsize, &pos, s->bit_length)       < 0) return -1;
+
+        uint8_t dbl[8];
+        write_be_double(dbl, s->scale);
+        if (buf_write(buf, bufsize, &pos, dbl, 8) < 0) return -1;
+        write_be_double(dbl, s->offset_val);
+        if (buf_write(buf, bufsize, &pos, dbl, 8) < 0) return -1;
+        write_be_double(dbl, s->min_val);
+        if (buf_write(buf, bufsize, &pos, dbl, 8) < 0) return -1;
+        write_be_double(dbl, s->max_val);
+        if (buf_write(buf, bufsize, &pos, dbl, 8) < 0) return -1;
+
+        uint16_t plen  = (uint16_t)(pos - payload_start);
+        buf[len_pos]   = (uint8_t)((plen >> 8) & 0xFF);
+        buf[len_pos+1] = (uint8_t)(plen & 0xFF);
+        count++;
+    }
+
+    /* ── PDUs ── */
+    for (int i = 0; i < g_pdu_count; i++) {
+        const pdu_def_t *pu = &g_pdus[i];
+        uint8_t name_len = (uint8_t)strlen(pu->name);
+
+        if (buf_write1(buf, bufsize, &pos, DEF_TYPE_PDU) < 0) return -1;
+        size_t len_pos = pos; pos += 2;
+        if (pos > bufsize) return -1;
+        size_t payload_start = pos;
+
+        if (buf_write1(buf, bufsize, &pos, name_len)              < 0) return -1;
+        if (buf_write(buf, bufsize, &pos, pu->name, name_len)     < 0) return -1;
+        if (buf_write1(buf, bufsize, &pos, pu->length)            < 0) return -1;
+        if (buf_write1(buf, bufsize, &pos, pu->signal_count)      < 0) return -1;
+
+        for (int j = 0; j < (int)pu->signal_count; j++) {
+            uint8_t slen = (uint8_t)strlen(pu->signals[j].sig_name);
+            if (buf_write1(buf, bufsize, &pos, slen)                         < 0) return -1;
+            if (buf_write(buf, bufsize, &pos, pu->signals[j].sig_name, slen) < 0) return -1;
+            if (buf_write1(buf, bufsize, &pos, pu->signals[j].start_bit)     < 0) return -1;
+        }
+
+        uint16_t plen  = (uint16_t)(pos - payload_start);
+        buf[len_pos]   = (uint8_t)((plen >> 8) & 0xFF);
+        buf[len_pos+1] = (uint8_t)(plen & 0xFF);
+        count++;
+    }
+
+    /* ── Frames ── */
+    for (int i = 0; i < g_frame_count; i++) {
+        const frame_def_t *fr = &g_frames[i];
+        uint8_t name_len = (uint8_t)strlen(fr->name);
+
+        if (buf_write1(buf, bufsize, &pos, DEF_TYPE_FRAME) < 0) return -1;
+        size_t len_pos = pos; pos += 2;
+        if (pos > bufsize) return -1;
+        size_t payload_start = pos;
+
+        if (buf_write1(buf, bufsize, &pos, name_len)               < 0) return -1;
+        if (buf_write(buf, bufsize, &pos, fr->name, name_len)      < 0) return -1;
+
+        uint8_t can_id_buf[4] = {
+            (uint8_t)((fr->can_id >> 24) & 0xFF),
+            (uint8_t)((fr->can_id >> 16) & 0xFF),
+            (uint8_t)((fr->can_id >>  8) & 0xFF),
+            (uint8_t)( fr->can_id        & 0xFF)
+        };
+        if (buf_write(buf, bufsize, &pos, can_id_buf, 4)           < 0) return -1;
+        if (buf_write1(buf, bufsize, &pos, fr->id_type)            < 0) return -1;
+        if (buf_write1(buf, bufsize, &pos, fr->dlc)                < 0) return -1;
+
+        uint8_t period_buf[2] = {
+            (uint8_t)((fr->tx_period >> 8) & 0xFF),
+            (uint8_t)( fr->tx_period       & 0xFF)
+        };
+        if (buf_write(buf, bufsize, &pos, period_buf, 2)           < 0) return -1;
+        if (buf_write1(buf, bufsize, &pos, fr->pdu_count)          < 0) return -1;
+
+        for (int j = 0; j < (int)fr->pdu_count; j++) {
+            uint8_t plen2 = (uint8_t)strlen(fr->pdus[j].pdu_name);
+            if (buf_write1(buf, bufsize, &pos, plen2)                           < 0) return -1;
+            if (buf_write(buf, bufsize, &pos, fr->pdus[j].pdu_name, plen2)      < 0) return -1;
+            if (buf_write1(buf, bufsize, &pos, fr->pdus[j].byte_offset)         < 0) return -1;
+        }
+
+        uint16_t plen  = (uint16_t)(pos - payload_start);
+        buf[len_pos]   = (uint8_t)((plen >> 8) & 0xFF);
+        buf[len_pos+1] = (uint8_t)(plen & 0xFF);
+        count++;
+    }
+
+    if (count_out)
+        *count_out = count;
+    return (ssize_t)pos;
+}
+
+/* -------------------------------------------------------------------------
+ * def_validate_entry  — conflict-check only, no apply
+ * ---------------------------------------------------------------------- */
+
+int def_validate_entry(uint8_t entry_type, const uint8_t *payload, uint32_t len)
+{
+    if (entry_type < DEF_TYPE_SIGNAL || entry_type > DEF_TYPE_FRAME)
+        return DEF_APPLY_INVALID;
+    if (len < 2u)
+        return DEF_APPLY_INVALID;
+
+    uint8_t name_len = payload[0];
+    if (name_len == 0 || name_len > PROTO_MAX_NAME ||
+        len < (uint32_t)(1u + name_len))
+        return DEF_APPLY_INVALID;
+
+    char name[PROTO_MAX_NAME + 1];
+    memcpy(name, payload + 1, name_len);
+    name[name_len] = '\0';
+
+    uint8_t existing = namespace_type(name);
+    if (existing != 0 && existing != entry_type)
+        return DEF_APPLY_CONFLICT;
+
+    return DEF_APPLY_OK;
+}
+
+/* -------------------------------------------------------------------------
+ * def_apply_entry  — full parse + insert/overwrite
+ * ---------------------------------------------------------------------- */
+
+void def_apply_entry(uint8_t entry_type, const uint8_t *payload, uint32_t len)
+{
+    if (len < 2u)
+        return;
+
+    uint8_t name_len = payload[0];
+    if (name_len == 0 || name_len > PROTO_MAX_NAME ||
+        len < (uint32_t)(1u + name_len))
+        return;
+
+    char name[PROTO_MAX_NAME + 1];
+    memcpy(name, payload + 1, name_len);
+    name[name_len] = '\0';
+
+    const uint8_t *p         = payload + 1 + name_len;
+    uint32_t       remaining = len - 1u - name_len;
+
+    if (entry_type == DEF_TYPE_SIGNAL) {
+        if (remaining < 35u) return;
+
+        uint8_t data_type  = *p++; remaining--;
+        uint8_t byte_order = *p++; remaining--;
+        uint8_t bit_length = *p++; remaining--;
+
+        if (data_type < 0x01u || data_type > 0x03u ||
+            byte_order < 0x01u || byte_order > 0x02u ||
+            bit_length == 0)
+            return;
+
+        double scale      = read_be_double(p); p += 8; remaining -= 8;
+        double offset_val = read_be_double(p); p += 8; remaining -= 8;
+        double min_val    = read_be_double(p); p += 8; remaining -= 8;
+        double max_val    = read_be_double(p); p += 8; remaining -= 8;
+        (void)remaining;
+
+        signal_def_t *slot = signal_find(name);
+        if (!slot) {
+            if (g_signal_count >= MAX_SIGNALS) return;
+            slot = &g_signals[g_signal_count++];
+        }
+        memcpy(slot->name, name, name_len + 1);
+        slot->data_type  = data_type;
+        slot->byte_order = byte_order;
+        slot->bit_length = bit_length;
+        slot->scale      = scale;
+        slot->offset_val = offset_val;
+        slot->min_val    = min_val;
+        slot->max_val    = max_val;
+
+    } else if (entry_type == DEF_TYPE_PDU) {
+        if (remaining < 2u) return;
+
+        uint8_t pdu_length   = *p++; remaining--;
+        uint8_t signal_count = *p++; remaining--;
+
+        if (signal_count > MAX_SIGNALS_PER_PDU) return;
+
+        pdu_signal_mapping_t mappings[MAX_SIGNALS_PER_PDU];
+
+        for (int i = 0; i < (int)signal_count; i++) {
+            if (remaining < 1u) return;
+            uint8_t sname_len = *p++; remaining--;
+
+            if (sname_len == 0 || sname_len > PROTO_MAX_NAME ||
+                remaining < (uint32_t)sname_len + 1u)
+                return;
+
+            char sname[PROTO_MAX_NAME + 1];
+            memcpy(sname, p, sname_len);
+            sname[sname_len] = '\0';
+            p += sname_len; remaining -= sname_len;
+
+            uint8_t start_bit = *p++; remaining--;
+
+            if (!signal_find(sname)) return;   /* reference must exist */
+
+            memcpy(mappings[i].sig_name, sname, sname_len + 1);
+            mappings[i].start_bit = start_bit;
+        }
+
+        pdu_def_t *slot = pdu_find(name);
+        if (!slot) {
+            if (g_pdu_count >= MAX_PDUS) return;
+            slot = &g_pdus[g_pdu_count++];
+        }
+        memcpy(slot->name, name, name_len + 1);
+        slot->length       = pdu_length;
+        slot->signal_count = signal_count;
+        memcpy(slot->signals, mappings, signal_count * sizeof(pdu_signal_mapping_t));
+
+    } else if (entry_type == DEF_TYPE_FRAME) {
+        if (remaining < 9u) return;
+
+        uint32_t can_id = ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16)
+                        | ((uint32_t)p[2] <<  8) |  (uint32_t)p[3];
+        p += 4; remaining -= 4;
+
+        uint8_t  id_type   = *p++; remaining--;
+        uint8_t  dlc       = *p++; remaining--;
+        uint16_t tx_period = (uint16_t)(((uint16_t)p[0] << 8) | p[1]);
+        p += 2; remaining -= 2;
+        uint8_t  pdu_count = *p++; remaining--;
+
+        if ((id_type != 0x01u && id_type != 0x02u) ||
+            pdu_count > MAX_PDUS_PER_FRAME)
+            return;
+
+        frame_pdu_mapping_t mappings[MAX_PDUS_PER_FRAME];
+
+        for (int i = 0; i < (int)pdu_count; i++) {
+            if (remaining < 1u) return;
+            uint8_t pname_len = *p++; remaining--;
+
+            if (pname_len == 0 || pname_len > PROTO_MAX_NAME ||
+                remaining < (uint32_t)pname_len + 1u)
+                return;
+
+            char pname[PROTO_MAX_NAME + 1];
+            memcpy(pname, p, pname_len);
+            pname[pname_len] = '\0';
+            p += pname_len; remaining -= pname_len;
+
+            uint8_t byte_offset = *p++; remaining--;
+
+            if (!pdu_find(pname)) return;       /* reference must exist */
+
+            memcpy(mappings[i].pdu_name, pname, pname_len + 1);
+            mappings[i].byte_offset = byte_offset;
+        }
+
+        frame_def_t *slot = frame_find(name);
+        if (!slot) {
+            if (g_frame_count >= MAX_FRAMES) return;
+            slot = &g_frames[g_frame_count++];
+        }
+        memcpy(slot->name, name, name_len + 1);
+        slot->can_id    = can_id;
+        slot->id_type   = id_type;
+        slot->dlc       = dlc;
+        slot->tx_period = tx_period;
+        slot->pdu_count = pdu_count;
+        memcpy(slot->pdus, mappings, pdu_count * sizeof(frame_pdu_mapping_t));
+    }
 }

--- a/server/def.h
+++ b/server/def.h
@@ -9,11 +9,45 @@
  * a name may not be used simultaneously for different types.
  * ---------------------------------------------------------------------- */
 
+#include <stdint.h>
+#include <stddef.h>
+#include <sys/types.h>
+
 void def_init(void);
 void def_destroy(void);
 void def_register_handlers(void);
 
 /* Returns 1 if a signal with the given name is defined, 0 otherwise. */
 int def_signal_exists(const char *name);
+
+/* -------------------------------------------------------------------------
+ * Serialization / deserialization  (used by cfg.c for persistence)
+ * ---------------------------------------------------------------------- */
+
+/* Return codes for def_validate_entry / def_apply_entry */
+#define DEF_APPLY_OK       0
+#define DEF_APPLY_CONFLICT 1
+#define DEF_APPLY_INVALID  2
+
+/*
+ * Serialize all in-memory definitions into buf[0..bufsize-1].
+ * Each entry is: type(1B) + payload_len(2B BE) + payload(N B).
+ * Sets *count_out to the number of entries written.
+ * Returns bytes written on success, or -1 if buf is too small.
+ */
+ssize_t def_serialize_entries(uint8_t *buf, size_t bufsize, uint16_t *count_out);
+
+/*
+ * Validate one entry (conflict-check only) without applying it.
+ * entry_type: DEF_TYPE_SIGNAL/PDU/FRAME (0x01/0x02/0x03)
+ * Returns DEF_APPLY_OK, DEF_APPLY_CONFLICT, or DEF_APPLY_INVALID.
+ */
+int def_validate_entry(uint8_t entry_type, const uint8_t *payload, uint32_t len);
+
+/*
+ * Apply one entry to the in-memory store (insert or overwrite).
+ * Silently ignores malformed payloads or unresolvable references.
+ */
+void def_apply_entry(uint8_t entry_type, const uint8_t *payload, uint32_t len);
 
 #endif /* ASH_SERVER_DEF_H */

--- a/server/server.c
+++ b/server/server.c
@@ -4,6 +4,7 @@
 #include "iface.h"
 #include "def.h"
 #include "own.h"
+#include "cfg.h"
 
 #include <sys/epoll.h>
 #include <sys/signalfd.h>
@@ -231,6 +232,11 @@ int server_init(server_t *s, uint16_t port, const char *storage_dir)
     /* --- Ownership module --- */
     own_init(s);
     own_register_handlers();
+
+    /* --- Configuration persistence --- */
+    cfg_init(s->storage_dir);
+    cfg_register_handlers();
+    cfg_autoload();
 
     printf("ash-server listening on port %u\n", (unsigned)port);
     return 0;

--- a/tools/test_client.py
+++ b/tools/test_client.py
@@ -4,6 +4,7 @@ ash protocol test client — exercises wire protocol and session lifecycle.
 
 Usage:
     ./tools/test_client.py [--host HOST] [--port PORT] [--test N]
+                           [--storage-dir DIR]
 
 Default host/port: 127.0.0.1:4000
 
@@ -14,6 +15,9 @@ Tests 18-28 (definition store) run automatically.
 Tests 29-36 (signal ownership) run automatically.
 Tests 37-39 (CAP_NET_ADMIN) run automatically; they self-skip when the server
 holds CAP_NET_ADMIN.
+Tests 40-43 (configuration persistence) run automatically; tests 40, 42, and 43
+self-skip when the server has no storage dir.  Pass --storage-dir to match the
+directory given to ash-server --storage-dir.
 Test 8 (graceful server shutdown) requires manually stopping the server and
 must be requested with --test 8.
 Test 9 (keep-alive timeout) waits 30+ seconds and must be requested with --test 9.
@@ -22,6 +26,7 @@ waits, and must be requested with --test 17.
 """
 
 import argparse
+import os
 import socket
 import struct
 import sys
@@ -83,6 +88,15 @@ ERR_DEF_INVALID   = 0x0020
 ERR_DEF_CONFLICT  = 0x0021
 ERR_DEF_IN_USE    = 0x0022
 
+# Configuration persistence (SPEC §9)
+MSG_CFG_SAVE    = 0x0040
+MSG_CFG_LOAD    = 0x0041
+MSG_CFG_ACK     = 0x8040
+
+ERR_CFG_IO        = 0x0040
+ERR_CFG_CHECKSUM  = 0x0041
+ERR_CFG_CONFLICT  = 0x0042
+
 DEF_TYPE_SIGNAL = 0x01
 DEF_TYPE_PDU    = 0x02
 DEF_TYPE_FRAME  = 0x03
@@ -91,6 +105,9 @@ KEEPALIVE_TIMEOUT_SEC    = 30
 
 # vcan interface name used by tests 10-17
 TEST_VCAN = 'vcan99'
+
+# Storage directory for cfg tests 40-43 (set from --storage-dir in main)
+_storage_dir = None
 
 # ── Frame helpers ─────────────────────────────────────────────────────────────
 
@@ -176,6 +193,9 @@ MSG_NAMES = {
     0x0033: 'OWN_UNLOCK',
     0x8030: 'OWN_ACK',
     0x9001: 'NOTIFY_OWN_REVOKED',
+    0x0040: 'CFG_SAVE',
+    0x0041: 'CFG_LOAD',
+    0x8040: 'CFG_ACK',
     0xFFFF: 'MSG_ERR',
 }
 
@@ -195,6 +215,9 @@ ERR_NAMES = {
     0x0022: 'ERR_DEF_IN_USE',
     0x0030: 'ERR_OWN_NOT_AVAILABLE',
     0x0031: 'ERR_OWN_NOT_HELD',
+    0x0040: 'ERR_CFG_IO',
+    0x0041: 'ERR_CFG_CHECKSUM',
+    0x0042: 'ERR_CFG_CONFLICT',
 }
 
 def fmt_type(t):
@@ -1521,6 +1544,218 @@ def test_own_session_close_releases(host, port):
         _delete_signal(s2, 't36_sig')
 
 
+# ── Configuration persistence helpers ────────────────────────────────────────
+
+def make_cfg_save(name):
+    """Build a CFG_SAVE frame (SPEC §9.3)."""
+    n = name.encode()
+    return make_frame(PROTO_VERSION, MSG_CFG_SAVE, bytes([len(n)]) + n)
+
+
+def make_cfg_load(name):
+    """Build a CFG_LOAD frame (SPEC §9.4)."""
+    n = name.encode()
+    return make_frame(PROTO_VERSION, MSG_CFG_LOAD, bytes([len(n)]) + n)
+
+
+# ── Configuration persistence tests (SPEC §9) ─────────────────────────────────
+
+def test_cfg_save_load_roundtrip(host, port):
+    """Test 40 — CFG_SAVE / CFG_LOAD round-trip.
+
+    Defines a signal, saves the store, deletes the signal, reloads, and
+    verifies the signal is accessible again.  Self-skips when the server has
+    no storage directory (CFG_SAVE returns ERR_CFG_IO).
+    """
+    print('\n[40] CFG_SAVE/LOAD round-trip — save defs, delete, reload, verify')
+    with open_session(host, port, 'cfg-roundtrip')[0] as s:
+        if not _define_signal(s, 't40_sig'):
+            check(False, 'DEF_SIGNAL prerequisite failed')
+            return
+
+        # Save
+        s.sendall(make_cfg_save('t40_rt'))
+        frame = recv_frame(s)
+        print_response(frame)
+        if not check(frame is not None, 'received a response to CFG_SAVE'):
+            def_cleanup(s, ('t40_sig', DEF_TYPE_SIGNAL))
+            return
+        _, msg_type, payload = frame
+        if msg_type == MSG_ERR:
+            code, _ = decode_err(payload)
+            if code == ERR_CFG_IO:
+                print('  [skip] server has no storage dir — start with --storage-dir')
+                def_cleanup(s, ('t40_sig', DEF_TYPE_SIGNAL))
+                return
+        if not check(msg_type == MSG_CFG_ACK,
+                     f'CFG_SAVE → CFG_ACK (got {fmt_type(msg_type)})'):
+            def_cleanup(s, ('t40_sig', DEF_TYPE_SIGNAL))
+            return
+
+        # Delete the signal (no deps)
+        s.sendall(make_def_delete('t40_sig', DEF_TYPE_SIGNAL))
+        if recv_frame(s) is None:
+            check(False, 'DEF_DELETE prerequisite failed')
+            return
+
+        # Reload
+        s.sendall(make_cfg_load('t40_rt'))
+        frame2 = recv_frame(s)
+        print_response(frame2)
+        if not check(frame2 is not None, 'received a response to CFG_LOAD'):
+            return
+        _, msg_type2, _ = frame2
+        if not check(msg_type2 == MSG_CFG_ACK,
+                     f'CFG_LOAD → CFG_ACK (got {fmt_type(msg_type2)})'):
+            return
+
+        # Verify signal is back by defining a PDU referencing it
+        s.sendall(make_def_pdu('t40_pdu', 8, [('t40_sig', 0)]))
+        frame3 = recv_frame(s)
+        if not check(frame3 is not None and frame3[1] == MSG_DEF_ACK,
+                     'signal accessible after reload (DEF_PDU → DEF_ACK)'):
+            def_cleanup(s, ('t40_sig', DEF_TYPE_SIGNAL))
+            return
+
+        def_cleanup(s, ('t40_sig', DEF_TYPE_SIGNAL), ('t40_pdu', DEF_TYPE_PDU))
+
+
+def test_cfg_load_nonexistent(host, port):
+    """Test 41 — CFG_LOAD of a nonexistent config name → ERR_CFG_IO."""
+    print('\n[41] CFG_LOAD nonexistent name — expect ERR_CFG_IO')
+    with open_session(host, port, 'cfg-nofile')[0] as s:
+        s.sendall(make_cfg_load('t41_no_such_config_xyz'))
+        frame = recv_frame(s)
+        print_response(frame)
+        if not check(frame is not None, 'received a response'):
+            return
+        _, msg_type, payload = frame
+        check(msg_type == MSG_ERR,
+              f'response is MSG_ERR (got {fmt_type(msg_type)})')
+        code, _ = decode_err(payload)
+        check(code == ERR_CFG_IO,
+              f'err_code is ERR_CFG_IO (got {fmt_err(code)})')
+
+
+def test_cfg_load_conflict(host, port):
+    """Test 42 — CFG_LOAD conflicts with in-memory type → ERR_CFG_CONFLICT.
+
+    Saves a signal named 't42_name', then redefines 't42_name' as a PDU, then
+    loads the saved file — the file has a signal where memory has a PDU.
+    Self-skips when the server has no storage directory.
+    """
+    print('\n[42] CFG_LOAD conflict — file has signal X, memory has PDU X → ERR_CFG_CONFLICT')
+    with open_session(host, port, 'cfg-conflict')[0] as s:
+        # Define signal t42_name
+        if not _define_signal(s, 't42_name'):
+            check(False, 'DEF_SIGNAL prerequisite failed')
+            return
+
+        # Save (file will contain signal t42_name)
+        s.sendall(make_cfg_save('t42_conf'))
+        frame = recv_frame(s)
+        if frame is None:
+            check(False, 'CFG_SAVE prerequisite: no response')
+            def_cleanup(s, ('t42_name', DEF_TYPE_SIGNAL))
+            return
+        _, msg_type, payload = frame
+        if msg_type == MSG_ERR:
+            code, _ = decode_err(payload)
+            if code == ERR_CFG_IO:
+                print('  [skip] server has no storage dir — start with --storage-dir')
+                def_cleanup(s, ('t42_name', DEF_TYPE_SIGNAL))
+                return
+        if msg_type != MSG_CFG_ACK:
+            check(False, f'CFG_SAVE prerequisite failed (got {fmt_type(msg_type)})')
+            def_cleanup(s, ('t42_name', DEF_TYPE_SIGNAL))
+            return
+
+        # Delete signal t42_name so we can redefine it as a PDU
+        s.sendall(make_def_delete('t42_name', DEF_TYPE_SIGNAL))
+        if recv_frame(s) is None:
+            check(False, 'DEF_DELETE prerequisite failed')
+            return
+
+        # Define t42_helper (needed for the PDU to reference)
+        if not _define_signal(s, 't42_helper'):
+            check(False, 'DEF_SIGNAL (helper) prerequisite failed')
+            return
+
+        # Redefine t42_name as a PDU
+        s.sendall(make_def_pdu('t42_name', 8, [('t42_helper', 0)]))
+        if recv_frame(s) is None:
+            check(False, 'DEF_PDU prerequisite failed')
+            def_cleanup(s, ('t42_helper', DEF_TYPE_SIGNAL))
+            return
+
+        # Load — file has signal t42_name, memory has PDU t42_name → conflict
+        s.sendall(make_cfg_load('t42_conf'))
+        frame2 = recv_frame(s)
+        print_response(frame2)
+        if not check(frame2 is not None, 'received a response to CFG_LOAD'):
+            def_cleanup(s, ('t42_helper', DEF_TYPE_SIGNAL),
+                        ('t42_name', DEF_TYPE_PDU))
+            return
+        _, msg_type2, payload2 = frame2
+        check(msg_type2 == MSG_ERR,
+              f'response is MSG_ERR (got {fmt_type(msg_type2)})')
+        code2, _ = decode_err(payload2)
+        check(code2 == ERR_CFG_CONFLICT,
+              f'err_code is ERR_CFG_CONFLICT (got {fmt_err(code2)})')
+
+        def_cleanup(s, ('t42_helper', DEF_TYPE_SIGNAL), ('t42_name', DEF_TYPE_PDU))
+
+
+def test_cfg_load_bad_checksum(host, port):
+    """Test 43 — CFG_LOAD of a file with a corrupted CRC → ERR_CFG_CHECKSUM.
+
+    Writes a minimal .ashcfg file with a deliberately wrong CRC into the
+    storage directory.  Requires --storage-dir to match the server's
+    --storage-dir; self-skips otherwise.
+    """
+    print('\n[43] CFG_LOAD bad checksum — expect ERR_CFG_CHECKSUM'
+          ' (skipped if --storage-dir not provided)')
+    if not _storage_dir:
+        print('  [skip] --storage-dir not provided')
+        return
+
+    # Write a file with valid header fields but CRC = 0x00000000 (wrong)
+    path = os.path.join(_storage_dir, 't43_badcrc.ashcfg')
+    magic   = 0x41534843
+    version = 0x0001
+    count   = 0
+    bad_crc = 0x00000000   # intentionally wrong (correct CRC for empty body ≠ 0)
+    # '>IHHI': magic(uint32) + version(uint16) + count(uint16) + crc(uint32)
+    header = struct.pack('>I', magic) + struct.pack('>H', version) + \
+             struct.pack('>H', count) + struct.pack('>I', bad_crc)
+
+    try:
+        os.makedirs(_storage_dir, exist_ok=True)
+        with open(path, 'wb') as f:
+            f.write(header)
+    except OSError as e:
+        print(f'  [skip] cannot write to storage dir: {e}')
+        return
+
+    with open_session(host, port, 'cfg-badcrc')[0] as s:
+        s.sendall(make_cfg_load('t43_badcrc'))
+        frame = recv_frame(s)
+        print_response(frame)
+        if not check(frame is not None, 'received a response'):
+            return
+        _, msg_type, payload = frame
+        check(msg_type == MSG_ERR,
+              f'response is MSG_ERR (got {fmt_type(msg_type)})')
+        code, _ = decode_err(payload)
+        check(code == ERR_CFG_CHECKSUM,
+              f'err_code is ERR_CFG_CHECKSUM (got {fmt_err(code)})')
+
+    try:
+        os.remove(path)
+    except OSError:
+        pass
+
+
 # ── CAP_NET_ADMIN tests ───────────────────────────────────────────────────────
 
 ERR_PERMISSION_DENIED = 0x0013
@@ -1665,19 +1900,29 @@ TESTS = [
     test_cap_net_admin_vcan_create,     # 37
     test_cap_net_admin_vcan_destroy,    # 38
     test_cap_net_admin_attach_bitrate,  # 39
+    test_cfg_save_load_roundtrip,       # 40
+    test_cfg_load_nonexistent,          # 41
+    test_cfg_load_conflict,             # 42
+    test_cfg_load_bad_checksum,         # 43
 ]
 
-AUTO_TESTS = TESTS[:7] + TESTS[9:16] + TESTS[17:]  # 1-7, 10-16, and 18-39 run unattended
+AUTO_TESTS = TESTS[:7] + TESTS[9:16] + TESTS[17:]  # 1-7, 10-16, and 18-43 run unattended
 
 
 def main():
+    global _storage_dir
+
     parser = argparse.ArgumentParser(
         description='ash protocol + session lifecycle test client')
     parser.add_argument('--host', default='127.0.0.1')
     parser.add_argument('--port', type=int, default=4000)
+    parser.add_argument('--storage-dir', default=None,
+                        help='path matching ash-server --storage-dir (needed for tests 40, 42, 43)')
     parser.add_argument('--test', type=int, choices=range(1, len(TESTS) + 1),
                         metavar='N', help=f'run only test N (1-{len(TESTS)})')
     args = parser.parse_args()
+
+    _storage_dir = args.storage_dir
 
     print(f'ash test client — {args.host}:{args.port}')
 
@@ -1697,7 +1942,7 @@ def main():
         print('\n[8]  Graceful shutdown    — run with --test 8')
         print('[9]  Keep-alive timeout  — run with --test 9 (takes 35 s)')
         print('[17] NOTIFY_IFACE_DOWN   — run with --test 17 (requires manual ip link delete)')
-        print('     (Tests 18-28 run automatically above)')
+        print('     (Tests 18-43 run automatically above)')
 
     print()
 

--- a/tools/test_client.py
+++ b/tools/test_client.py
@@ -1719,12 +1719,14 @@ def test_cfg_load_bad_checksum(host, port):
         print('  [skip] --storage-dir not provided')
         return
 
-    # Write a file with valid header fields but CRC = 0x00000000 (wrong)
+    # Write a file with valid header fields but a wrong CRC.
+    # Note: CRC32 of an empty body is 0x00000000 (0xFFFFFFFF ^ 0xFFFFFFFF),
+    # so 0x00000000 would actually pass validation.  Use 0xDEADBEEF instead.
     path = os.path.join(_storage_dir, 't43_badcrc.ashcfg')
     magic   = 0x41534843
     version = 0x0001
     count   = 0
-    bad_crc = 0x00000000   # intentionally wrong (correct CRC for empty body ≠ 0)
+    bad_crc = 0xDEADBEEF   # intentionally wrong (correct CRC for empty body = 0x00000000)
     # '>IHHI': magic(uint32) + version(uint16) + count(uint16) + crc(uint32)
     header = struct.pack('>I', magic) + struct.pack('>H', version) + \
              struct.pack('>H', count) + struct.pack('>I', bad_crc)


### PR DESCRIPTION
## Summary

- Implements `CFG_SAVE` and `CFG_LOAD` message handlers (SPEC §9)
- Binary `.ashcfg` file format: `ASHC` magic + CRC32 (IEEE 802.3) + definition entries in DEF_* wire format
- `CFG_LOAD` is atomic: conflict-checks all entries before applying any; returns `ERR_CFG_CHECKSUM` on bad CRC, `ERR_CFG_CONFLICT` on type mismatch
- `cfg_autoload()` loads all `*.ashcfg` files in the storage directory at server startup
- Tests 40–43 cover: save/load round-trip, nonexistent file (`ERR_CFG_IO`), type conflict (`ERR_CFG_CONFLICT`), and bad checksum (`ERR_CFG_CHECKSUM`)

## Test plan

- [ ] Build with `cmake --build build` — no errors
- [ ] Start server with `--storage-dir /tmp/ash-test`, run `tools/test_client.py --storage-dir /tmp/ash-test`; tests 40–43 pass (40, 42, 43 require `--storage-dir`)
- [ ] Tests 40/42 self-skip cleanly when no `--storage-dir` is provided
- [ ] Test 43 self-skips when `--storage-dir` not provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)