### PR TITLE
#11: Cyclic Frame Transmission — on_disconnect policies (SPEC §11.3)

### DIFF
--- a/server/app.c
+++ b/server/app.c
@@ -785,6 +785,69 @@ static void app_handle_cyclic_timer(int timer_fd)
 }
 
 /* -------------------------------------------------------------------------
+ * app_session_cleanup  — apply on_disconnect policies (SPEC §11.3)
+ * ---------------------------------------------------------------------- */
+
+typedef struct {
+    uint32_t session_id;
+} app_disc_ctx_t;
+
+static void apply_signal_on_disconnect(const char *sig_name,
+                                        uint8_t on_disconnect, void *ctx_)
+{
+    app_disc_ctx_t *ctx = (app_disc_ctx_t *)ctx_;
+
+    if (on_disconnect == 0x02u) /* last: keep cycling unchanged */
+        return;
+
+    def_sig_info_t info;
+    if (def_resolve_signal(sig_name, &info) != 0)
+        return;
+    if (info.frame_tx_period == 0)
+        return; /* event-driven frame — no timer to manage */
+
+    uint8_t abs_start = (uint8_t)((int)info.pdu_byte_offset * 8
+                                  + (int)info.start_bit);
+
+    for (int i = 0; i < MAX_CYCLIC_FRAMES; i++) {
+        if (g_cyclic[i].can_sock_fd < 0)
+            continue;
+        if (strcmp(g_cyclic[i].frame_name, info.frame_name) != 0)
+            continue;
+
+        /* Zero this signal's bits in the data buffer */
+        if (info.byte_order == 0x01u)
+            pack_bits_le(g_cyclic[i].data, 0u, abs_start, info.bit_length);
+        else
+            pack_bits_be(g_cyclic[i].data, 0u, abs_start, info.bit_length);
+
+        if (on_disconnect == 0x03u) { /* default: physical = offset */
+            def_update_signal_value(sig_name, info.offset_val);
+        } else { /* stop */
+            /* Disarm timer only if no continuing signal remains in this frame */
+            if (!own_frame_has_continuing_signal(info.frame_name,
+                                                  ctx->session_id)) {
+                if (g_cyclic[i].timer_fd >= 0) {
+                    struct itimerspec its;
+                    memset(&its, 0, sizeof(its));
+                    timerfd_settime(g_cyclic[i].timer_fd, 0, &its, NULL);
+                    server_del_fd(g_server, g_cyclic[i].timer_fd);
+                    close(g_cyclic[i].timer_fd);
+                    g_cyclic[i].timer_fd = -1;
+                }
+                g_cyclic[i].can_sock_fd = -1;
+            }
+        }
+    }
+}
+
+void app_session_cleanup(uint32_t session_id)
+{
+    app_disc_ctx_t ctx = { session_id };
+    own_foreach_session_signal(session_id, apply_signal_on_disconnect, &ctx);
+}
+
+/* -------------------------------------------------------------------------
  * app_iface_attached / app_iface_detach
  * ---------------------------------------------------------------------- */
 

--- a/server/app.h
+++ b/server/app.h
@@ -29,6 +29,13 @@
 void app_init(server_t *s);
 void app_destroy(void);
 
+/*
+ * Apply on_disconnect policies for all signals owned by session_id.
+ * Must be called before own_session_cleanup() so ownership records are
+ * still intact for the "all stopped" check.  (SPEC §11.3)
+ */
+void app_session_cleanup(uint32_t session_id);
+
 /* Called by iface.c when an interface is attached */
 void app_iface_attached(const char *iface_name, int can_fd, int app_listen_fd);
 

--- a/server/own.c
+++ b/server/own.c
@@ -353,17 +353,38 @@ void own_session_cleanup(uint32_t session_id)
 {
     for (int i = 0; i < g_own_count; i++) {
         if (g_own[i].session_id == session_id) {
-            /*
-             * on_disconnect policy note: cyclic frame management (stop /
-             * last / default) will be enforced in the application-plane
-             * runtime (SPEC §10).  For now we simply release ownership so
-             * the signal becomes available for re-acquisition.
-             */
             g_own[i].session_id = 0;
             g_own[i].client_fd  = -1;
             g_own[i].locked     = 0;
         }
     }
+}
+
+void own_foreach_session_signal(uint32_t session_id, own_signal_cb_t cb,
+                                void *ctx)
+{
+    for (int i = 0; i < g_own_count; i++) {
+        if (g_own[i].session_id == session_id)
+            cb(g_own[i].sig_name, g_own[i].on_disconnect, ctx);
+    }
+}
+
+int own_frame_has_continuing_signal(const char *frame_name,
+                                    uint32_t skip_session_id)
+{
+    for (int i = 0; i < g_own_count; i++) {
+        if (g_own[i].session_id == 0 ||
+            g_own[i].session_id == skip_session_id)
+            continue;
+        if (g_own[i].on_disconnect == 0x01u) /* stop */
+            continue;
+        def_sig_info_t info;
+        if (def_resolve_signal(g_own[i].sig_name, &info) != 0)
+            continue;
+        if (strcmp(info.frame_name, frame_name) == 0)
+            return 1;
+    }
+    return 0;
 }
 
 /* -------------------------------------------------------------------------

--- a/server/own.h
+++ b/server/own.h
@@ -24,4 +24,24 @@ void own_session_cleanup(uint32_t session_id);
  */
 int own_session_owns_signal(uint32_t session_id, const char *sig_name);
 
+/* Callback type for own_foreach_session_signal. */
+typedef void (*own_signal_cb_t)(const char *sig_name, uint8_t on_disconnect,
+                                void *ctx);
+
+/*
+ * Iterate over all signals owned by `session_id`, calling `cb` for each
+ * before ownership is released.  Used by app.c to apply on_disconnect
+ * policies prior to own_session_cleanup().
+ */
+void own_foreach_session_signal(uint32_t session_id, own_signal_cb_t cb,
+                                void *ctx);
+
+/*
+ * Returns 1 if any signal mapped to `frame_name` is currently owned by a
+ * session other than `skip_session_id` with on_disconnect != stop (0x01).
+ * Used by app.c to decide whether to keep a cyclic timer alive.
+ */
+int own_frame_has_continuing_signal(const char *frame_name,
+                                    uint32_t skip_session_id);
+
 #endif /* ASH_SERVER_OWN_H */

--- a/server/session.c
+++ b/server/session.c
@@ -2,6 +2,7 @@
 #include "proto.h"
 #include "iface.h"
 #include "own.h"
+#include "app.h"
 
 #include "ash/proto.h"
 
@@ -72,6 +73,7 @@ void session_arm_timer(session_t *sess)
 void session_cleanup(server_t *s, session_t *sess)
 {
     if (sess->session_id != 0) {
+        app_session_cleanup(sess->session_id);
         own_session_cleanup(sess->session_id);
         iface_session_cleanup(s, sess->session_id);
     }


### PR DESCRIPTION
## Summary

- Implements `on_disconnect` policy enforcement for cyclic frames on session teardown (SPEC §11.3)
- The timerfd creation, expiry handler, and `app_cyclic_t` tracking were already in place from #10; this PR adds the missing policy logic

## Changes

- **`own.h/own.c`**: Add `own_foreach_session_signal` (iterate a session's owned signals) and `own_frame_has_continuing_signal` (check if any `last`/`default` signal keeps a frame alive); remove stale TODO comment from `own_session_cleanup`
- **`app.h/app.c`**: Add `app_session_cleanup(session_id)` — iterates the session's signals, applies policy per signal:
  - `stop` (`0x01`): zero signal bits in frame data buffer; if no continuing signal remains, disarm and close the timerfd
  - `last` (`0x02`): no-op — frame keeps cycling at last written value
  - `default` (`0x03`): zero signal bits, update cached value to `offset_val`; frame keeps cycling
- **`session.c`**: Call `app_session_cleanup` before `own_session_cleanup` in `session_cleanup` so ownership records are still intact for the "all stopped" check

## Test plan

- [ ] Cyclic frame with single `stop` signal: timer disarmed on session disconnect
- [ ] Cyclic frame with single `last` signal: timer keeps firing after disconnect
- [ ] Cyclic frame with single `default` signal: bits zeroed, timer keeps firing
- [ ] Mixed `stop` + `last` in same frame: timer survives until `last`-owning session also disconnects
- [x] Clean build — no warnings

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)